### PR TITLE
Add network only param for multisite

### DIFF
--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -7,6 +7,7 @@ Version: 1.1.0
 Author: WordPress.com Special Projects / Nick Green
 Author URI: https://wpspecialprojects.wordpress.com/
 License: GPLv3
+Network: true
 */
 
 


### PR DESCRIPTION
### Suggested changes

Add network: true param so the plugin can only be activated in Network Only on multi-sites and not on children's sites.