### PR TITLE
Add/update uri

### DIFF
--- a/class-plugin-autoupdate-filter-self-update.php
+++ b/class-plugin-autoupdate-filter-self-update.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Plugin Autoupdate Filter Self Update class
+ * sets up autoupdates for this GitHub-hosted plugin
+ *
+ * @package Plugin_Autoupdate_Filter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class Plugin_Autoupdate_Filter_Self_Update {
+
+	/**
+	 * Plugin_Autoupdate_Filter_Self_Update constructor.
+	 */
+	public function __construct() {
+		add_filter( 'update_plugins_github.com', array( $this, 'self_update' ), 10, 4 );
+	}
+
+	/**
+	 * Check for updates to this plugin
+	 *
+	 * @param array  $update   Array of update data.
+	 * @param array  $plugin_data Array of plugin data.
+	 * @param string $plugin_file Path to plugin file.
+	 * @param string $locales    Locale code.
+	 *
+	 * @return array|bool Array of update data or false if no update available.
+	 */
+	public function self_update( $update, array $plugin_data, string $plugin_file, $locales ) {
+		// only check this plugin
+		if ( 'plugin-autoupdate-filter/plugin-autoupdate-filter.php' !== $plugin_file ) {
+			return $update;
+		}
+
+		// already completed update check elsewhere
+		if ( ! empty( $update ) ) {
+			return $update;
+		}
+
+		// let's go get the latest version number from GitHub
+		$response = wp_remote_get(
+			'https://api.github.com/repos/a8cteam51/plugin-autoupdate-filter/releases/latest',
+			array(
+				'user-agent' => 'wpspecialprojects',
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return;
+		} else {
+			$output = json_decode( wp_remote_retrieve_body( $response ), true );
+		}
+
+		$new_version_number  = $output['tag_name'];
+		$is_update_available = version_compare( $plugin_data['Version'], $new_version_number, '<' );
+
+		if ( ! $is_update_available ) {
+			return false;
+		}
+
+		$new_url     = $output['html_url'];
+		$new_package = $output['assets'][0]['browser_download_url'];
+
+		return array(
+			'slug'    => $plugin_data['Slug'],
+			'version' => $new_version_number,
+			'url'     => $new_url,
+			'package' => $new_package,
+		);
+	}
+}
+new Plugin_Autoupdate_Filter_Self_Update();

--- a/class-plugin-autoupdate-filter-self-update.php
+++ b/class-plugin-autoupdate-filter-self-update.php
@@ -65,7 +65,7 @@ class Plugin_Autoupdate_Filter_Self_Update {
 		$new_package = $output['assets'][0]['browser_download_url'];
 
 		return array(
-			'slug'    => $plugin_data['Slug'],
+			'slug'    => $plugin_data['TextDomain'],
 			'version' => $new_version_number,
 			'url'     => $new_url,
 			'package' => $new_package,

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -1,27 +1,29 @@
 <?php
+/**
+ * Plugin Autoupdate Filter class
+ *
+ * @package Plugin_Autoupdate_Filter
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
 class Plugin_Autoupdate_Filter {
 
+	/**
+	 * Plugin_Autoupdate_Filter constructor.
+	 */
 	public function __construct() {
 
 		// setup plugins to autoupdate _unless_ it's during specific day/time
 		add_filter( 'auto_update_plugin', array( $this, 'auto_update_specific_times' ), 10, 2 );
 
 		// Replace automatic update wording on plugin management page in admin
-		add_filter(
-			'plugin_auto_update_setting_html',
-			function( $html, $plugin_file, $plugin_data ) {
-				return 'Automatic updates managed by <strong>Plugin Autoupdate Filter</strong>';
-			},
-			11,
-			3
-		);
+		add_filter( 'plugin_auto_update_setting_html', array( $this, 'plugin_autoupdate_filter_custom_setting_html' ), 11, 3 );
 
 		// Always send auto-update emails to T51 concierge email address
-		add_filter( 'auto_plugin_theme_update_email', 'plugin_autoupdate_filter_custom_update_emails', 4, 10 );
+		add_filter( 'auto_plugin_theme_update_email', array( $this, 'plugin_autoupdate_filter_custom_update_emails' ), 4, 10 );
 
 		// re-enable core update emails which are disabled in an mu-plugin at the Atomic platform level
 		add_filter( 'automatic_updates_send_debug_email', '__return_true', 11 );
@@ -31,7 +33,14 @@ class Plugin_Autoupdate_Filter {
 
 	}
 
-	// setup plugins to autoupdate _unless_ it's during specific day/time
+	/**
+	 * Enable or disable plugin auto-updates based on time and day of the week.
+	 *
+	 * @param bool   $update Whether to update the plugin or not.
+	 * @param object $item   The plugin update object.
+	 *
+	 * @return bool True to update, false to not update.
+	 */
 	public function auto_update_specific_times( $update, $item ) {
 
 		$holidays = array(
@@ -77,10 +86,32 @@ class Plugin_Autoupdate_Filter {
 			return true;
 	}
 
-	// Always send auto-update emails to T51
+	/**
+	 * Customize auto-update email recipients.
+	 *
+	 * @param array  $email              Array of email data.
+	 * @param string $type               Type of email to send.
+	 * @param array  $successful_updates Array of successful updates.
+	 * @param array  $failed_updates     Array of failed updates.
+	 *
+	 * @return array Array of email data with modified recipient email.
+	 */
 	public function plugin_autoupdate_filter_custom_update_emails( $email, $type, $successful_updates, $failed_updates ) {
 		$email['to'] = 'concierge@wordpress.com';
 		return $email;
+	}
+
+	/**
+	 * Customize automatic update setting HTML for plugins page in wp-admin.
+	 *
+	 * @param string $html       HTML for automatic update settings.
+	 * @param string $plugin_file Path to plugin file.
+	 * @param array  $plugin_data Array of plugin data.
+	 *
+	 * @return string Customized HTML for automatic update settings.
+	 */
+	public function plugin_autoupdate_filter_custom_setting_html( $html, $plugin_file, $plugin_data ) {
+		return 'Automatic updates managed by <strong>Plugin Autoupdate Filter</strong>';
 	}
 }
 new Plugin_Autoupdate_Filter();

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -3,7 +3,7 @@
 Plugin Name: Plugin Autoupdate Filter
 Plugin URI: https://github.com/a8cteam51/plugin-autoupdate-filter
 Description: Sets plugin automatic updates to always on, but only happen during specific days and times.
-Version: 1.2.0
+Version: 1.3.0
 Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 Update URI: https://github.com/a8cteam51/plugin-autoupdate-filter/

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -21,7 +21,7 @@ require_once dirname( __FILE__ ) . '/class-plugin-autoupdate-filter.php';
 // sets up autoupdates for this plugin, even though it's hosted on GitHub
 add_filter( 'update_plugins_github.com', function( $update, array $plugin_data, string $plugin_file, $locales ) {
     // only check this plugin
-    if ( $plugin_file !== 'plugin-autoupdate-filter.php' ) {
+    if ( $plugin_file !== 'plugin-autoupdate-filter/plugin-autoupdate-filter.php' ) {
         return $update;
     }
 

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -6,6 +6,7 @@ Description: Sets plugin automatic updates to always on, but only happen during 
 Version: 1.2.0
 Author: WordPress.com Special Projects / Nick Green
 Author URI: https://wpspecialprojects.wordpress.com/
+Update URI: https://github.com/a8cteam51/plugin-autoupdate-filter/
 License: GPLv3
 Network: true
 */
@@ -16,3 +17,38 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once dirname( __FILE__ ) . '/class-plugin-autoupdate-filter.php';
+
+// sets up autoupdates for this plugin, even though it's hosted on GitHub
+add_filter( 'update_plugins_github.com', function( $update, array $plugin_data, string $plugin_file, $locales ) {
+    // only check this plugin
+    if ( $plugin_file !== 'plugin-autoupdate-filter.php' ) {
+        return $update;
+    }
+
+    // already done update check elsewhere
+    if ( ! empty( $update ) ) {
+        return $update;
+    }
+
+	// let's go get the latest version number from GitHub 
+	$curl = curl_init();
+	curl_setopt( $curl, CURLOPT_URL, "https://api.github.com/repos/a8cteam51/plugin-autoupdate-filter/releases/latest" );  
+	curl_setopt( $curl, CURLOPT_USERAGENT, 'wpspecialprojects' );
+	curl_setopt( $curl, CURLOPT_RETURNTRANSFER, 1 );
+	$output = json_decode( curl_exec($curl), true );  
+	curl_close( $curl );
+
+	$new_version_number  = $output['tag_name'];	
+	$is_update_available = version_compare( $plugin_data['Version'], $new_version_number, '<' );
+
+    if ( ! $is_update_available ) {
+        return false;
+    }
+
+    return [
+        'slug'    => 'plugin-autoupdate-filter',
+        'version' => $new_version_number,
+        'url'     => 'https://github.com/a8cteam51/plugin-autoupdate-filter/',
+        'package' => 'https://github.com/a8cteam51/plugin-autoupdate-filter/releases/latest/download/plugin-autoupdate-filter.zip',
+    ];
+}, 10, 4 );

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -4,62 +4,19 @@ Plugin Name: Plugin Autoupdate Filter
 Plugin URI: https://github.com/a8cteam51/plugin-autoupdate-filter
 Description: Sets plugin automatic updates to always on, but only happen during specific days and times.
 Version: 1.2.0
-Author: WordPress.com Special Projects / Nick Green
+Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 Update URI: https://github.com/a8cteam51/plugin-autoupdate-filter/
 License: GPLv3
 Network: true
 */
 
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+// main plugin functionality
 require_once dirname( __FILE__ ) . '/class-plugin-autoupdate-filter.php';
 
-// sets up autoupdates for this GitHub-hosted plugin
-add_filter(
-	'update_plugins_github.com',
-	function( $update, array $plugin_data, string $plugin_file, $locales ) {
-		// only check this plugin
-		if ( 'plugin-autoupdate-filter/plugin-autoupdate-filter.php' !== $plugin_file ) {
-			return $update;
-		}
-
-		// already done update check elsewhere
-		if ( ! empty( $update ) ) {
-			return $update;
-		}
-
-		// let's go get the latest version number from GitHub
-		$response = wp_remote_get(
-			'https://api.github.com/repos/a8cteam51/plugin-autoupdate-filter/releases/latest',
-			array(
-				'user-agent' => 'wpspecialprojects',
-			)
-		);
-
-		if ( is_wp_error( $response ) ) {
-			return;
-		} else {
-			$output = json_decode( wp_remote_retrieve_body( $response ), true );
-		}
-
-		$new_version_number  = $output['tag_name'];
-		$is_update_available = version_compare( $plugin_data['Version'], $new_version_number, '<' );
-
-		if ( ! $is_update_available ) {
-			return false;
-		}
-
-		return array(
-			'slug'    => 'plugin-autoupdate-filter',
-			'version' => $new_version_number,
-			'url'     => 'https://github.com/a8cteam51/plugin-autoupdate-filter/',
-			'package' => 'https://github.com/a8cteam51/plugin-autoupdate-filter/releases/latest/download/plugin-autoupdate-filter.zip',
-		);
-	},
-	10,
-	4
-);
+// handles updating of the plugin itself
+require_once dirname( __FILE__ ) . '/class-plugin-autoupdate-filter-self-update.php';


### PR DESCRIPTION
## Synopsis

Sets up updates/autoupdates for the GitHub-hosted plugin. 

Based on the Update URI functionality, introduced in WP 5.8: https://make.wordpress.org/core/2021/06/29/introducing-update-uri-plugin-header-in-wordpress-5-8/

## To test

Load the latest version of the plugin onto a test site, and manually edit/change the version number to something less than the current version (1.2.0). When the site checks for updates, it should recognize that an update is available, and autoupdate the plugin.

Note: the update will show as available for manual update before it autoupdates. This is because the autoupdates only happen every 12 hours maximum, and are also filtered by the plugin itself to happen only during T51 business hours. So it might take up to 24 hours to see the autoupdate happen, even though the manual update will show much sooner.
