### PR TITLE
Fix fatal error

### DIFF
--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -23,8 +23,8 @@ class Plugin_Autoupdate_Filter {
 		add_filter( 'plugin_auto_update_setting_html', array( $this, 'plugin_autoupdate_filter_custom_setting_html' ), 11, 3 );
 
 		// Always send auto-update emails to T51 concierge email address
-		add_filter( 'auto_plugin_theme_update_email', array( $this, 'plugin_autoupdate_filter_custom_update_emails' ), 4, 10 );
-		add_filter( 'automatic_updates_debug_email', array( $this, 'plugin_autoupdate_filter_custom_debug_email' ), 3, 10 );
+		add_filter( 'auto_plugin_theme_update_email', array( $this, 'plugin_autoupdate_filter_custom_update_emails' ), 10, 4 );
+		add_filter( 'automatic_updates_debug_email', array( $this, 'plugin_autoupdate_filter_custom_debug_email' ), 10, 3 );
 
 		// re-enable core update emails which are disabled in an mu-plugin at the Atomic platform level
 		add_filter( 'automatic_updates_send_debug_email', '__return_true', 11 );

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -110,7 +110,7 @@ class Plugin_Autoupdate_Filter {
 	 *
 	 * @return array $email The email details with the 'to' address modified.
 	 */
-	public function plugin_autoupdate_filter_custom_debug_email( $email,   $failures,   $update_results ) {
+	public function plugin_autoupdate_filter_custom_debug_email( $email, $failures, $update_results ) {
 		$email['to'] = 'concierge@wordpress.com';
 		return $email;
 	}

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -3,7 +3,7 @@
 Plugin Name: Plugin Autoupdate Filter
 Plugin URI: https://github.com/a8cteam51/plugin-autoupdate-filter
 Description: Sets plugin automatic updates to always on, but only happen during specific days and times.
-Version: 1.4.0
+Version: 1.4.1
 Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 Update URI: https://github.com/a8cteam51/plugin-autoupdate-filter/


### PR DESCRIPTION
The method `Plugin_Autoupdate_Filter::plugin_autoupdate_filter_custom_debug_email` had a subtle bug that is causing PHP FatalError on all our sites.

Before the second and third arguments, it looks like there are a lot of spaces. However, there are two spaces and **one** no-break space character (NBSP). When PHP parses the file, it interprets the NBSP character as a class type; thus, an error is thrown when the hook is called.

This is the view in PHPStorm: ![m5iJMK.png](https://user-images.githubusercontent.com/36231502/217792936-c6ee989b-d385-49f3-a088-2abc28fdb4ae.png)

VS Code shows a yellow rectangle at that position: ![R3AQSd.png](https://user-images.githubusercontent.com/36231502/217793148-29f4dfe5-633c-4199-a081-5a7fb3a6fcca.png)

And, last but not least, here is the Unicode translation of that line before this PR:

<details>
<summary>Unicode translation (notice the U+00A0 characters)</summary>
<br>

```
U+0070 : LATIN SMALL LETTER P
U+0075 : LATIN SMALL LETTER U
U+0062 : LATIN SMALL LETTER B
U+006C : LATIN SMALL LETTER L
U+0069 : LATIN SMALL LETTER I
U+0063 : LATIN SMALL LETTER C
U+0020 : SPACE [SP]
U+0066 : LATIN SMALL LETTER F
U+0075 : LATIN SMALL LETTER U
U+006E : LATIN SMALL LETTER N
U+0063 : LATIN SMALL LETTER C
U+0074 : LATIN SMALL LETTER T
U+0069 : LATIN SMALL LETTER I
U+006F : LATIN SMALL LETTER O
U+006E : LATIN SMALL LETTER N
U+0020 : SPACE [SP]
U+0070 : LATIN SMALL LETTER P
U+006C : LATIN SMALL LETTER L
U+0075 : LATIN SMALL LETTER U
U+0067 : LATIN SMALL LETTER G
U+0069 : LATIN SMALL LETTER I
U+006E : LATIN SMALL LETTER N
U+005F : LOW LINE
U+0061 : LATIN SMALL LETTER A
U+0075 : LATIN SMALL LETTER U
U+0074 : LATIN SMALL LETTER T
U+006F : LATIN SMALL LETTER O
U+0075 : LATIN SMALL LETTER U
U+0070 : LATIN SMALL LETTER P
U+0064 : LATIN SMALL LETTER D
U+0061 : LATIN SMALL LETTER A
U+0074 : LATIN SMALL LETTER T
U+0065 : LATIN SMALL LETTER E
U+005F : LOW LINE
U+0066 : LATIN SMALL LETTER F
U+0069 : LATIN SMALL LETTER I
U+006C : LATIN SMALL LETTER L
U+0074 : LATIN SMALL LETTER T
U+0065 : LATIN SMALL LETTER E
U+0072 : LATIN SMALL LETTER R
U+005F : LOW LINE
U+0063 : LATIN SMALL LETTER C
U+0075 : LATIN SMALL LETTER U
U+0073 : LATIN SMALL LETTER S
U+0074 : LATIN SMALL LETTER T
U+006F : LATIN SMALL LETTER O
U+006D : LATIN SMALL LETTER M
U+005F : LOW LINE
U+0064 : LATIN SMALL LETTER D
U+0065 : LATIN SMALL LETTER E
U+0062 : LATIN SMALL LETTER B
U+0075 : LATIN SMALL LETTER U
U+0067 : LATIN SMALL LETTER G
U+005F : LOW LINE
U+0065 : LATIN SMALL LETTER E
U+006D : LATIN SMALL LETTER M
U+0061 : LATIN SMALL LETTER A
U+0069 : LATIN SMALL LETTER I
U+006C : LATIN SMALL LETTER L
U+0028 : LEFT PARENTHESIS
U+0020 : SPACE [SP]
U+0024 : DOLLAR SIGN {milréis, escudo}
U+0065 : LATIN SMALL LETTER E
U+006D : LATIN SMALL LETTER M
U+0061 : LATIN SMALL LETTER A
U+0069 : LATIN SMALL LETTER I
U+006C : LATIN SMALL LETTER L
U+002C : COMMA {decimal separator}
U+0020 : SPACE [SP]
U+00A0 : NO-BREAK SPACE [NBSP]
U+0020 : SPACE [SP]
U+0024 : DOLLAR SIGN {milréis, escudo}
U+0066 : LATIN SMALL LETTER F
U+0061 : LATIN SMALL LETTER A
U+0069 : LATIN SMALL LETTER I
U+006C : LATIN SMALL LETTER L
U+0075 : LATIN SMALL LETTER U
U+0072 : LATIN SMALL LETTER R
U+0065 : LATIN SMALL LETTER E
U+0073 : LATIN SMALL LETTER S
U+002C : COMMA {decimal separator}
U+0020 : SPACE [SP]
U+00A0 : NO-BREAK SPACE [NBSP]
U+0020 : SPACE [SP]
U+0024 : DOLLAR SIGN {milréis, escudo}
U+0075 : LATIN SMALL LETTER U
U+0070 : LATIN SMALL LETTER P
U+0064 : LATIN SMALL LETTER D
U+0061 : LATIN SMALL LETTER A
U+0074 : LATIN SMALL LETTER T
U+0065 : LATIN SMALL LETTER E
U+005F : LOW LINE
U+0072 : LATIN SMALL LETTER R
U+0065 : LATIN SMALL LETTER E
U+0073 : LATIN SMALL LETTER S
U+0075 : LATIN SMALL LETTER U
U+006C : LATIN SMALL LETTER L
U+0074 : LATIN SMALL LETTER T
U+0073 : LATIN SMALL LETTER S
U+0020 : SPACE [SP]
U+0029 : RIGHT PARENTHESIS
U+0020 : SPACE [SP]
U+007B : LEFT CURLY BRACKET {left brace}
```

</details>

