### PR TITLE
Change plugin page text if autoupdates blocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ add_filter( 'plugin_autoupdate_filter_holidays', 'custom_autoupdate_holidays' );
 ```
 
 ### Disable autoupdate completely for specific plugins
-If you still need to turn off autoupdates for a specific plugin, you can filter `auto_update_plugin` at a priority greater than 10, and prevent specific plugins from updating. e.g.:
+If you still need to turn off autoupdates for a specific plugin, you can filter `auto_update_plugin` at a priority greater than 10, and prevent specific plugins from updating.
+
+### NOTE: If you do this, please name your function `disable_autoupdate_specific_plugins`, so that we can add appropriate notices in wp-admin, e.g.
+
 ```
 function disable_autoupdate_specific_plugins ( $update, $item ) {
     // Array of plugin slugs to never auto-update

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -153,14 +153,21 @@ class Plugin_Autoupdate_Filter {
 	 */
 	public function plugin_autoupdate_filter_change_upgrade_message_for_specific_plugins() {
 
+		// check if updates are explicitly blocked for this plugin
+		if ( ! function_exists( 'disable_autoupdate_specific_plugins' ) ) {
+			return;
+		}
+
 		$all_plugins = get_plugins();
 
 		foreach ( $all_plugins as $plugin_file => $plugin_data ) {
 			// create a fake object to feed to disable_autoupdate_specific_plugins
 			$plugin_obj                    = new stdClass();
-			$plugin_obj->slug              = dirname( $plugin_file );
+			$slug                          = dirname( $plugin_file );
+			$plugin_obj->slug              = $slug;
 			$plugin_allowed_to_update_bool = disable_autoupdate_specific_plugins( true, $plugin_obj );
 			if ( false === $plugin_allowed_to_update_bool ) {
+				// add notice next to the "update now" link
 				add_filter(
 					"in_plugin_update_message-{$plugin_file}",
 					function () {
@@ -169,6 +176,17 @@ class Plugin_Autoupdate_Filter {
 					10,
 					2
 				);
+				// add notice to the top of the screen
+				global $pagenow;
+				if ( 'plugins.php' === $pagenow ) {
+					add_action(
+						'admin_notices',
+						function() use ( $slug ) {
+							echo '<div class="error"><p><strong style="color:red;"> Caution:</strong> Autoupdates have been explicitly deactivated for ', esc_html( $slug ), '. Please contact the WordPress Special Projects team before manually updating.</p></div>';
+						}
+					);
+
+				}
 			}
 		}
 	}

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -16,14 +16,19 @@ class Plugin_Autoupdate_Filter {
 	 */
 	public function init() {
 
-		// setup plugins to autoupdate _unless_ it's during specific day/time
+		// setup plugins and core to autoupdate _unless_ it's during specific day/time
 		add_filter( 'auto_update_plugin', array( $this, 'auto_update_specific_times' ), 10, 2 );
+		add_filter( 'auto_core_update_email', array( $this, 'plugin_autoupdate_filter_custom_update_emails' ), 10, 4 );
 
 		// Replace automatic update wording on plugin management page in admin
 		add_filter( 'plugin_auto_update_setting_html', array( $this, 'plugin_autoupdate_filter_custom_setting_html' ), 11, 3 );
 
+		//Append text to upgrade text on plugins page for plugins explicitly set to not autoupdate
+		add_action( 'admin_init', array( $this, 'plugin_autoupdate_filter_change_upgrade_message_for_specific_plugins' ) );
+
 		// Always send auto-update emails to T51 concierge email address
 		add_filter( 'auto_plugin_theme_update_email', array( $this, 'plugin_autoupdate_filter_custom_update_emails' ), 10, 4 );
+		add_filter( 'auto_core_update_email', array( $this, 'plugin_autoupdate_filter_custom_update_emails' ), 10, 4 );
 		add_filter( 'automatic_updates_debug_email', array( $this, 'plugin_autoupdate_filter_custom_debug_email' ), 10, 3 );
 
 		// re-enable core update emails which are disabled in an mu-plugin at the Atomic platform level
@@ -31,8 +36,6 @@ class Plugin_Autoupdate_Filter {
 		add_filter( 'auto_core_update_send_email', '__return_true', 11 );
 		add_filter( 'auto_plugin_update_send_email', '__return_true', 11 );
 		add_filter( 'auto_theme_update_send_email', '__return_true', 11 );
-
-		add_action( 'admin_init', array( $this, 'replace_upgrade_message_for_specific_plugins' ) );
 
 	}
 
@@ -148,7 +151,7 @@ class Plugin_Autoupdate_Filter {
 	 * Append text to upgrade text on plugins page for plugins explicitly set to not autoupdate
 	 *
 	 */
-	public function replace_upgrade_message_for_specific_plugins() {
+	public function plugin_autoupdate_filter_change_upgrade_message_for_specific_plugins() {
 
 		$all_plugins = get_plugins();
 

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -16,16 +16,14 @@ class Plugin_Autoupdate_Filter {
 	 */
 	public function init() {
 
-		// setup plugins and core to autoupdate _unless_ it's during specific day/time
+		// setup plugins to autoupdate _unless_ it's during specific day/time
 		add_filter( 'auto_update_plugin', array( $this, 'auto_update_specific_times' ), 10, 2 );
-		add_filter( 'auto_update_core', array( $this, 'auto_update_specific_times' ), 10, 2 );
 
 		// Replace automatic update wording on plugin management page in admin
 		add_filter( 'plugin_auto_update_setting_html', array( $this, 'plugin_autoupdate_filter_custom_setting_html' ), 11, 3 );
 
 		// Always send auto-update emails to T51 concierge email address
 		add_filter( 'auto_plugin_theme_update_email', array( $this, 'plugin_autoupdate_filter_custom_update_emails' ), 10, 4 );
-		add_filter( 'auto_core_update_email', array( $this, 'plugin_autoupdate_filter_custom_update_emails' ), 10, 4 );
 		add_filter( 'automatic_updates_debug_email', array( $this, 'plugin_autoupdate_filter_custom_debug_email' ), 10, 3 );
 
 		// re-enable core update emails which are disabled in an mu-plugin at the Atomic platform level
@@ -33,6 +31,8 @@ class Plugin_Autoupdate_Filter {
 		add_filter( 'auto_core_update_send_email', '__return_true', 11 );
 		add_filter( 'auto_plugin_update_send_email', '__return_true', 11 );
 		add_filter( 'auto_theme_update_send_email', '__return_true', 11 );
+
+		add_action( 'admin_init', array( $this, 'replace_upgrade_message_for_specific_plugins' ) );
 
 	}
 
@@ -127,7 +127,47 @@ class Plugin_Autoupdate_Filter {
 	 * @return string Customized HTML for automatic update settings.
 	 */
 	public function plugin_autoupdate_filter_custom_setting_html( $html, $plugin_file, $plugin_data ) {
+
+		// check if updates are explicitly blocked for this plugin
+		if ( function_exists( 'disable_autoupdate_specific_plugins' ) ) {
+
+			// create a fake object to feed to disable_autoupdate_specific_plugins
+			$plugin_obj                    = new stdClass();
+			$plugin_obj->slug              = dirname( $plugin_file );
+			$plugin_allowed_to_update_bool = disable_autoupdate_specific_plugins( true, $plugin_obj );
+
+			if ( false === $plugin_allowed_to_update_bool ) {
+				return 'Autoupdates have been explicitly deactivated for this plugin.';
+			}
+		}
+
 		return 'Automatic updates managed by <strong>Plugin Autoupdate Filter</strong>';
+	}
+
+	/**
+	 * Append text to upgrade text on plugins page for plugins explicitly set to not autoupdate
+	 *
+	 */
+	public function replace_upgrade_message_for_specific_plugins() {
+
+		$all_plugins = get_plugins();
+
+		foreach ( $all_plugins as $plugin_file => $plugin_data ) {
+			// create a fake object to feed to disable_autoupdate_specific_plugins
+			$plugin_obj                    = new stdClass();
+			$plugin_obj->slug              = dirname( $plugin_file );
+			$plugin_allowed_to_update_bool = disable_autoupdate_specific_plugins( true, $plugin_obj );
+			if ( false === $plugin_allowed_to_update_bool ) {
+				add_filter(
+					"in_plugin_update_message-{$plugin_file}",
+					function () {
+						echo ' <strong style="color:red;"> Caution:</strong> Autoupdates have been explicitly deactivated for this plugin. Please contact the WordPress Special Projects team before manually updating.';
+					},
+					10,
+					2
+				);
+			}
+		}
 	}
 
 }

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -18,7 +18,7 @@ class Plugin_Autoupdate_Filter {
 
 		// setup plugins and core to autoupdate _unless_ it's during specific day/time
 		add_filter( 'auto_update_plugin', array( $this, 'auto_update_specific_times' ), 10, 2 );
-		add_filter( 'auto_core_update_email', array( $this, 'plugin_autoupdate_filter_custom_update_emails' ), 10, 4 );
+		add_filter( 'auto_update_core', array( $this, 'auto_update_specific_times' ), 10, 2 );
 
 		// Replace automatic update wording on plugin management page in admin
 		add_filter( 'plugin_auto_update_setting_html', array( $this, 'plugin_autoupdate_filter_custom_setting_html' ), 11, 3 );

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -3,7 +3,7 @@
 Plugin Name: Plugin Autoupdate Filter
 Plugin URI: https://github.com/a8cteam51/plugin-autoupdate-filter
 Description: Sets plugin automatic updates to always on, but only happen during specific days and times.
-Version: 1.4.2
+Version: 1.4.3
 Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 Update URI: https://github.com/a8cteam51/plugin-autoupdate-filter/


### PR DESCRIPTION
### Changes in this PR

- Change autoupdate text if autoupdates are explicitly disabled
- Append cautionary text to the manual update link if autoupdates are explicitly disabled
- Update README to let folks know that they need to adhere to a specific naming convention when disabling autoupdates

![SCR-20230903-qtjy](https://github.com/a8cteam51/plugin-autoupdate-filter/assets/2067992/5f42cbd9-9fbc-4c7d-865b-6ac3047be5b0)

### Notes

- This will only work if the autoupdates have been explicitly declared using a function named `disable_autoupdate_specific_plugins`. I'm not sure there's another way to do this, but if so, let me know
- Also looking for general good code practices suggestions.