### PR TITLE
Make holidays year-agnostic

### DIFF
--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -51,8 +51,12 @@ class Plugin_Autoupdate_Filter {
 
 		$holidays = array(
 			'christmas' => array(
-				'start' => '2021-12-23 00:00:00',
-				'end'   => '2021-12-26 00:00:00',
+				'start' => gmdate( "Y" ) . '-12-23 00:00:00',
+				'end'   => gmdate( "Y" ) . '-12-31 23:59:59',
+			),
+			'new_years' => array(
+				'start' => gmdate( "Y" ) . '-01-01 00:00:00',
+				'end'   => gmdate( "Y" ) . '-01-02 23:59:59',
 			),
 		);
 		$holidays = apply_filters( 'plugin_autoupdate_filter_holidays', $holidays );

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -3,7 +3,7 @@
 Plugin Name: Plugin Autoupdate Filter
 Plugin URI: https://github.com/a8cteam51/plugin-autoupdate-filter
 Description: Sets plugin automatic updates to always on, but only happen during specific days and times.
-Version: 1.4.3
+Version: 1.4.4
 Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 Update URI: https://github.com/a8cteam51/plugin-autoupdate-filter/


### PR DESCRIPTION
Making Xmas and New Year's year-agnostic (apparently I had hard coded the year in previously).

Splitting the dates into two different sections, so as to avoid complicated "plus-one year" math, which also makes the whole thing more readable.