### PR TITLE
Revert "Incident: Prevent WooCommerce from updating"

### DIFF
--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -48,11 +48,6 @@ class Plugin_Autoupdate_Filter {
 	 * @return bool True to update, false to not update.
 	 */
 	public function auto_update_specific_times( $update, $item ) {
-		// Check if the plugin being updated has the slug 'woocommerce'
-		if ( isset( $item->slug ) && 'woocommerce' === $item->slug ) {
-			// Explicitly prevent auto-updates for WooCommerce by returning false
-			return false;
-		}
 
 		$holidays = array(
 			'christmas' => array(
@@ -97,8 +92,8 @@ class Plugin_Autoupdate_Filter {
 			return false;
 		}
 
-		// Otherwise, plugins will autoupdate regardless of settings in wp-admin
-		return true;
+			// Otherwise, plugins will autoupdate regardless of settings in wp-admin
+			return true;
 	}
 
 	/**

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -3,7 +3,7 @@
 Plugin Name: Plugin Autoupdate Filter
 Plugin URI: https://github.com/a8cteam51/plugin-autoupdate-filter
 Description: Sets plugin automatic updates to always on, but only happen during specific days and times.
-Version: 1.4.5
+Version: 1.4.4
 Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 Update URI: https://github.com/a8cteam51/plugin-autoupdate-filter/


### PR DESCRIPTION
Reverting since this isn't preventing woocommerce updates for (yet) unknown reasons.