### PR TITLE
Add/restrict updates until woo 8.6.1

### DIFF
--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -59,8 +59,8 @@ class Plugin_Autoupdate_Filter {
 				'end'   => gmdate( "Y" ) . '-01-02 23:59:59',
 			),
 			'wait_for_next_woo_release' => array(
-				'start' => gmdate( "Y" ) . '-02-16 00:00:00',
-				'end'   => gmdate( "Y" ) . '-02-21 23:59:59',
+				'start' => gmdate( "Y" ) . '2024-02-16 00:00:00',
+				'end'   => gmdate( "Y" ) . '2024-02-20 23:59:59',
 			),
 		);
 		$holidays = apply_filters( 'plugin_autoupdate_filter_holidays', $holidays );
@@ -96,8 +96,8 @@ class Plugin_Autoupdate_Filter {
 			return false;
 		}
 
-			// Otherwise, plugins will autoupdate regardless of settings in wp-admin
-			return true;
+		// Otherwise, plugins will autoupdate regardless of settings in wp-admin
+		return true;
 	}
 
 	/**

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -63,6 +63,10 @@ class Plugin_Autoupdate_Filter {
 				'start' => gmdate( "Y" ) . '-01-01 00:00:00',
 				'end'   => gmdate( "Y" ) . '-01-02 23:59:59',
 			),
+			'wait_for_next_woo_release' => array(
+				'start' => gmdate( "Y" ) . '-02-16 00:00:00',
+				'end'   => gmdate( "Y" ) . '-02-21 23:59:59',
+			),
 		);
 		$holidays = apply_filters( 'plugin_autoupdate_filter_holidays', $holidays );
 

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -59,8 +59,8 @@ class Plugin_Autoupdate_Filter {
 				'end'   => gmdate( "Y" ) . '-01-02 23:59:59',
 			),
 			'wait_for_next_woo_release' => array(
-				'start' => gmdate( "Y" ) . '2024-02-16 00:00:00',
-				'end'   => gmdate( "Y" ) . '2024-02-20 23:59:59',
+				'start' => '2024-02-16 00:00:00',
+				'end'   => '2024-02-20 23:59:59',
 			),
 		);
 		$holidays = apply_filters( 'plugin_autoupdate_filter_holidays', $holidays );

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -3,7 +3,7 @@
 Plugin Name: Plugin Autoupdate Filter
 Plugin URI: https://github.com/a8cteam51/plugin-autoupdate-filter
 Description: Sets plugin automatic updates to always on, but only happen during specific days and times.
-Version: 1.4.5
+Version: 1.4.6
 Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 Update URI: https://github.com/a8cteam51/plugin-autoupdate-filter/


### PR DESCRIPTION
Don't update anything until woocommerce 8.6.1 is released.  

Currently targeting release date of 02-20-2024.