### PR TITLE
Feature/killswitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ By default, the plugin always returns `true` for autoupdates Mon-Thu 6am-7pm Eas
 
 ### Centralized settings
 
-By default, this plugin checks an endpoint set up by the WordPress Special Projects team to get centralized settings. If you use this and aren't part of the team, then we recommend you either set up your own endpoint or remove that portion of the code. 
+By default, this plugin checks an endpoint set up by the WordPress Special Projects team to get centralized settings. If you use this plugin and aren't part of the team, then we recommend you either set up your own endpoint or remove that portion of the code. 
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
-# plugin-autoupdate-filter
-Sets plugin automatic updates to always on, but only happen during specific days and times.
+| :exclamation:  This is a public repository |
+|--------------------------------------------|
+
+# Plugin Autoupdate Filter
+Filters whether autoupdates are on based on day/time and other settings.
+
+## What's this?
+This is a plugin that the WordPress Special Projects team uses on many of their partner sites in order to help manage autoupdates in a responsible way. For example:
+1. It defaults autoupdates to be on. Keeping plugins up-to-date is one of the the first lines of defense against malicious attacks and technical debt.
+2. It provides various mechanisms by which we can turn off autoupdates, such as during specific days/times, for specific plugins, or centralized settings which can turn off all autoupdates.
 
 ## Usage
 
@@ -13,6 +21,10 @@ This plugin filters the core `auto_update_plugin` functionality to always run au
 It's a good idea to load this as a normal plugin (rather than an mu-plugin), so that it can be deactivated easily by a site admin, in case autoupdates needs to be paused during troubleshooting, etc.
 
 By default, the plugin always returns `true` for autoupdates Mon-Thu 6am-7pm Eastern, and Fri 6am-3pm Eastern. The 13 hour days are because the cron event which checks for autoupdates only runs every 12 hours, and so if the window isn't more than 12 hours at least once during the week, we run the risk of missing updates completely.
+
+### Centralized settings
+
+By default, this plugin checks an endpoint set up by the WordPress Special Projects team to get centralized settings. If you use this and aren't part of the team, then we recommend you either set up your own endpoint or remove that portion of the code. 
 
 ## Support
 
@@ -61,7 +73,7 @@ add_filter( 'plugin_autoupdate_filter_holidays', 'custom_autoupdate_holidays' );
 ### Disable autoupdate completely for specific plugins
 If you still need to turn off autoupdates for a specific plugin, you can filter `auto_update_plugin` at a priority greater than 10, and prevent specific plugins from updating.
 
-### NOTE: If you do this, please name your function `disable_autoupdate_specific_plugins`, so that we can add appropriate notices in wp-admin, e.g.
+**NOTE: If you do this, please name your function `disable_autoupdate_specific_plugins`**, so that we can add appropriate notices in wp-admin, e.g.
 
 ```
 function disable_autoupdate_specific_plugins ( $update, $item ) {

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -34,19 +34,19 @@ class Plugin_Autoupdate_Filter {
 		}
 
 		// setup plugins and core to autoupdate _unless_ it's during specific day/time
-		add_filter( 'auto_update_plugin', array( $this, 'auto_update_specific_times' ), 10, 2 );
-		add_filter( 'auto_update_core', array( $this, 'auto_update_specific_times' ), 10, 2 );
+		add_filter( 'auto_update_plugin', array( $this, 'filter_auto_update_specific_times' ), 10, 2 );
+		add_filter( 'auto_update_core', array( $this, 'filter_auto_update_specific_times' ), 10, 2 );
 
 		// Replace automatic update wording on plugin management page in admin
-		add_filter( 'plugin_auto_update_setting_html', array( $this, 'custom_setting_html' ), 11, 3 );
+		add_filter( 'plugin_auto_update_setting_html', array( $this, 'filter_custom_setting_html' ), 11, 3 );
 
 		//Append text to upgrade text on plugins page for plugins explicitly set to not autoupdate
-		add_action( 'admin_init', array( $this, 'upgrade_message_for_specific_plugins' ) );
+		add_action( 'admin_init', array( $this, 'output_upgrade_message_for_specific_plugins' ) );
 
 		// Always send auto-update emails to T51 concierge email address
-		add_filter( 'auto_plugin_theme_update_email', array( $this, 'custom_update_emails' ), 10, 4 );
-		add_filter( 'auto_core_update_email', array( $this, 'custom_update_emails' ), 10, 4 );
-		add_filter( 'automatic_updates_debug_email', array( $this, 'custom_debug_email' ), 10, 3 );
+		add_filter( 'auto_plugin_theme_update_email', array( $this, 'filter_custom_update_emails' ), 10, 4 );
+		add_filter( 'auto_core_update_email', array( $this, 'filter_custom_update_emails' ), 10, 4 );
+		add_filter( 'automatic_updates_debug_email', array( $this, 'filter_custom_debug_email' ), 10, 3 );
 
 		// re-enable core update emails which are disabled in an mu-plugin at the Atomic platform level
 		add_filter( 'automatic_updates_send_debug_email', '__return_true', 11 );
@@ -55,46 +55,57 @@ class Plugin_Autoupdate_Filter {
 		add_filter( 'auto_theme_update_send_email', '__return_true', 11 );
 
 		// "Disable all autoupdates" toggle
-		add_filter( 'auto_update_plugin', array( $this, 'maybe_disable_all_autoupdates' ), PHP_INT_MAX, 2 );
-		add_filter( 'auto_update_core', array( $this, 'maybe_disable_all_autoupdates' ), PHP_INT_MAX, 2 );
-		add_filter( 'auto_update_theme', array( $this, 'maybe_disable_all_autoupdates' ), PHP_INT_MAX, 2 );
-		add_action( 'admin_init', array( $this, 'autoupdate_settings_admin_notice' ) );
+		add_filter( 'auto_update_plugin', array( $this, 'filter_maybe_disable_all_autoupdates' ), PHP_INT_MAX, 2 );
+		add_filter( 'auto_update_core', array( $this, 'filter_maybe_disable_all_autoupdates' ), PHP_INT_MAX, 2 );
+		add_filter( 'auto_update_theme', array( $this, 'filter_maybe_disable_all_autoupdates' ), PHP_INT_MAX, 2 );
+		add_action( 'admin_init', array( $this, 'output_auto_updates_disabled_admin_notice' ) );
 
 	}
 
 	/**
 	 * Load settings from the centralized settings page
 	 */
-	private function get_auto_update_settings(): stdClass|WP_Error {
+	private function get_auto_update_settings(): stdClass {
 
-		$response = wp_remote_get(
-			'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/autoupdate-plugin/v1/settings/',
-			array( 'headers' => array( 'Accept' => 'application/json' ) )
-		);
+		// Try getting the settings from the transient first
+		$transient_key = 'auto_update_settings';
+		$settings      = get_transient( $transient_key );
 
-		if ( is_wp_error( $response ) ) {
-			throw new RuntimeException( $response->get_error_message(), $response->get_error_code() );
+		if ( false === $settings ) {
+			$response = wp_safe_remote_get(
+				'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/autoupdate-plugin/v1/settings/',
+				array( 'headers' => array( 'Accept' => 'application/json' ) )
+			);
+
+			if ( is_wp_error( $response ) ) {
+				throw new RuntimeException( $response->get_error_message(), $response->get_error_code() );
+			}
+
+			$response_code = wp_remote_retrieve_response_code( $response );
+			$response_body = wp_remote_retrieve_body( $response );
+
+			// Check that the response code is a 2xx code.
+			if ( ! \str_starts_with( (string) $response_code, '2' ) ) {
+				$response_message = wp_remote_retrieve_response_message( $response );
+				throw new Exception( $response_message, $response_code );
+			}
+
+			$decoded_body = json_decode( $response_body, false, 512, JSON_THROW_ON_ERROR );
+
+			// Save the settings in a transient for 5 minutes
+			set_transient( $transient_key, $decoded_body, 5 * MINUTE_IN_SECONDS );
+
+			// if the settings are empty, we still need to return an object
+			if ( ! is_object( $decoded_body ) ) {
+				$object              = new stdClass();
+				$object->placeholder = $decoded_body;
+				$decoded_body        = $object;
+			}
+
+			$settings = $decoded_body;
 		}
 
-		$response_code = wp_remote_retrieve_response_code( $response );
-		$response_body = wp_remote_retrieve_body( $response );
-
-		// Check that the response code is a 2xx code.
-		if ( ! \str_starts_with( (string) $response_code, '2' ) ) {
-			$response_message = wp_remote_retrieve_response_message( $response );
-			throw new Exception( $response_message, $response_code );
-		}
-
-		$decoded_body = json_decode( $response_body, false, 512, JSON_THROW_ON_ERROR );
-
-		// if the settings are empty, we still need to return an object
-		if ( ! is_object( $decoded_body ) ) {
-			$object              = new stdClass();
-			$object->placeholder = $decoded_body;
-			$decoded_body        = $object;
-		}
-
-		return $decoded_body;
+		return $settings;
 	}
 
 	/**
@@ -105,7 +116,7 @@ class Plugin_Autoupdate_Filter {
 	 *
 	 * @return bool True to update, false to not update.
 	 */
-	public function maybe_disable_all_autoupdates( $update, $item ): bool {
+	public function filter_maybe_disable_all_autoupdates( $update, $item ): bool {
 
 		if ( isset( $this->settings->disable_all ) ) {
 			return false;
@@ -122,7 +133,7 @@ class Plugin_Autoupdate_Filter {
 	 *
 	 * @return bool True to update, false to not update.
 	 */
-	public function auto_update_specific_times( $update, $item ): bool {
+	public function filter_auto_update_specific_times( $update, $item ): bool {
 
 		$holidays = array(
 			'christmas' => array(
@@ -181,7 +192,7 @@ class Plugin_Autoupdate_Filter {
 	 *
 	 * @return array Array of email data with modified recipient email.
 	 */
-	public function custom_update_emails( $email, $type, $successful_updates, $failed_updates ): array {
+	public function filter_custom_update_emails( $email, $type, $successful_updates, $failed_updates ): array {
 		$email['to'] = 'concierge@wordpress.com';
 		return $email;
 	}
@@ -194,7 +205,7 @@ class Plugin_Autoupdate_Filter {
 	 *
 	 * @return array $email The email details with the 'to' address modified.
 	 */
-	public function custom_debug_email( $email, $failures, $update_results ): array {
+	public function filter_custom_debug_email( $email, $failures, $update_results ): array {
 		$email['to'] = 'concierge@wordpress.com';
 		return $email;
 	}
@@ -208,7 +219,7 @@ class Plugin_Autoupdate_Filter {
 	 *
 	 * @return string Customized HTML for automatic update settings.
 	 */
-	public function custom_setting_html( $html, $plugin_file, $plugin_data ): string {
+	public function filter_custom_setting_html( $html, $plugin_file, $plugin_data ): string {
 
 		// check if updates are explicitly blocked for this plugin
 		if ( function_exists( 'disable_autoupdate_specific_plugins' ) ) {
@@ -230,7 +241,7 @@ class Plugin_Autoupdate_Filter {
 	 * Append text to upgrade text on plugins page for plugins explicitly set to not autoupdate
 	 *
 	 */
-	public function upgrade_message_for_specific_plugins(): void {
+	public function output_upgrade_message_for_specific_plugins(): void {
 
 		// check if updates are explicitly blocked for this plugin
 		// don't show if we are already disabling all updates
@@ -272,10 +283,10 @@ class Plugin_Autoupdate_Filter {
 	}
 
 	/**
-	 * Autoupdate filter settings admin notices
+	 * Autoupdates disabled admin notice
 	 *
 	 */
-	public function autoupdate_settings_admin_notice(): void {
+	public function output_auto_updates_disabled_admin_notice(): void {
 		// add notice to the top of the screen
 		global $pagenow;
 		if ( 'plugins.php' === $pagenow && isset( $this->settings->disable_all ) ) {

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -52,7 +52,7 @@ class Plugin_Autoupdate_Filter {
 	 * Load settings from the centralized settings page
 	 */
 	private function get_auto_update_settings() {
-		$endpoint_url = 'https://opsoasis.wpspecialprojects.com/wpcomsp/autoupdate-plugin/v1/settings/';
+		$endpoint_url = 'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/autoupdate-plugin/v1/settings/';
 		$response     = wp_remote_get( $endpoint_url );
 
 		// Check for `WP_Error`
@@ -103,7 +103,7 @@ class Plugin_Autoupdate_Filter {
 	 */
 	public function maybe_disable_all_autoupdates( $update, $item ) {
 
-		if ( $this->settings['error'] || ( isset ( $this->settings['team51_autoupdate_settings_disable_all_toggle'] ) && 'on' === $this->settings['team51_autoupdate_settings_disable_all_toggle'] ) ) {
+		if ( $this->settings['error'] || ( isset ( $this->settings['disable_all_toggle'] ) && 'on' === $this->settings['disable_all_toggle'] ) ) {
 			return false;
 		}
 
@@ -274,7 +274,7 @@ class Plugin_Autoupdate_Filter {
 		$message = '';
 		if ( $this->settings['error'] ) {
 			$message = 'Error retrieving autoupdate settings (' . $this->settings['error'] . '). ' ;
-		} elseif ( isset ( $this->settings['team51_autoupdate_settings_disable_all_toggle'] ) ) {
+		} elseif ( isset ( $this->settings['disable_all_toggle'] ) ) {
 			$message = 'All autoupdates are intentionally deactivated.';
 		}
 		// add notice to the top of the screen

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -71,7 +71,7 @@ class Plugin_Autoupdate_Filter {
 		$transient_key = 'auto_update_settings';
 		$settings      = get_transient( $transient_key );
 
-		if ( false === $settings ) {
+		if ( false === $settings || "" === $settings ) {
 			$response = wp_safe_remote_get(
 				'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/autoupdate-plugin/v1/settings/',
 				array( 'headers' => array( 'Accept' => 'application/json' ) )

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -81,8 +81,11 @@ class Plugin_Autoupdate_Filter {
 	 * @return bool True to update, false to not update.
 	 */
 	public function auto_update_killswitch( $update, $item ) {
+		if ( ! isset ( $this->settings['team51_autoupdate_settings_disable_all_toggle'] ) ) {
+			return ;
+		}
 
-		if ( isset( $this->settings['team51_autoupdate_settings_disable_all_toggle'] ) && 'on' === $this->settings['team51_autoupdate_settings_disable_all_toggle'] ) {
+		if ( isset ( $this->settings['team51_autoupdate_settings_disable_all_toggle'] ) && 'on' === $this->settings['team51_autoupdate_settings_disable_all_toggle'] ) {
 			return false;
 		}
 

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -92,15 +92,15 @@ class Plugin_Autoupdate_Filter {
 
 			$decoded_body = json_decode( $response_body, false, 512, JSON_THROW_ON_ERROR );
 
-			// Save the settings in a transient for 5 minutes
-			set_transient( $transient_key, $decoded_body, 5 * MINUTE_IN_SECONDS );
-
 			// if the settings are empty, we still need to return an object
 			if ( ! is_object( $decoded_body ) ) {
 				$object              = new stdClass();
 				$object->placeholder = $decoded_body;
 				$decoded_body        = $object;
 			}
+
+			// Save the settings in a transient for 5 minutes
+			set_transient( $transient_key, $decoded_body, 5 * MINUTE_IN_SECONDS );
 
 			$settings = $decoded_body;
 		}

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -68,10 +68,10 @@ class Plugin_Autoupdate_Filter {
 	private function get_auto_update_settings(): stdClass {
 
 		// Try getting the settings from the transient first
-		$transient_key = 'auto_update_settings';
+		$transient_key = 'wpcpmsp_auto_update_settings';
 		$settings      = get_transient( $transient_key );
 
-		if ( false === $settings || "" === $settings ) {
+		if ( empty( $settings ) ) {
 			$response = wp_safe_remote_get(
 				'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/autoupdate-plugin/v1/settings/',
 				array( 'headers' => array( 'Accept' => 'application/json' ) )

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -2,8 +2,8 @@
 /*
 Plugin Name: Plugin Autoupdate Filter
 Plugin URI: https://github.com/a8cteam51/plugin-autoupdate-filter
-Description: Sets plugin automatic updates to always on, but only happen during specific days and times.
-Version: 1.4.6
+Description: Filters whether autoupdates are on based on day/time and other settings.
+Version: 1.5.0
 Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 Update URI: https://github.com/a8cteam51/plugin-autoupdate-filter/


### PR DESCRIPTION
## Synopsis

Simplified version of the centralized settings here: https://github.com/a8cteam51/plugin-autoupdate-filter/pull/24

The point of this is to get an MVP up and running, with the most important feature, and then we can discuss and add the "Swiss Army Knife" features later.

## To Test

- This plugin is activated on opsoasis: https://github.com/a8cteam51/team51-autoupdate-settings
- The settings page is here, with a toggle switch: https://opsoasis.wpspecialprojects.com/wp-admin/tools.php?page=team51_autoupdate_settings_options
- The API endpoint is here: https://opsoasis.wpspecialprojects.com/wp-json/custom/v1/get_autoupdate_settings/

When that toggle switch is toggled on, then all autoupdates should stop happening, and a notice should appear on the top of the plugins page.

## Details

- **Caching:** The settings are cached, causing the killswitch to not immediately take effect. This is likely because the settings are retrieved when the object is created. However, I also tried it by retrieving the settings every single time the update filters ran, and it still seemed to not take effect immediately. I can deactivate/reactivate the Plugin Autoupdate Filter plugin to get it to register changes to the settings. Any thoughts on how to do this better are encouraged.
- **Naming of the killswitch:** as is being discussed in the other PR, I'm still waffling over the naming of the killswitch being confusing with the boolean return for the autoupdate filter itself. (i.e. Killswitch is "on" and return is "false")

Any other feedback is helpful, with the goal of getting out a minimum viable product that includes the killswitch, and we can add more features later :)