### PR TITLE
< PHP 8.0 compat type-hinting

### DIFF
--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -114,11 +114,11 @@ class Plugin_Autoupdate_Filter {
 	 * @param bool|null   $update Whether to update the plugin or not. This can be bool or null as per the docs
 	 * @param object $item   The plugin update object.
 	 *
-	 * @return bool|null True to update, false to not update.
+	 * @return bool True to update, false to not update.
 	 */
-	public function filter_maybe_disable_all_autoupdates( $update, $item ): bool|null {
+	public function filter_maybe_disable_all_autoupdates( $update, $item ): bool {
 
-		if ( isset( $this->settings->disable_all ) ) {
+		if ( isset( $this->settings->disable_all ) || null === $update ) {
 			return false;
 		}
 

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -3,7 +3,7 @@
 Plugin Name: Plugin Autoupdate Filter
 Plugin URI: https://github.com/a8cteam51/plugin-autoupdate-filter
 Description: Filters whether autoupdates are on based on day/time and other settings.
-Version: 1.5.0
+Version: 1.5.2
 Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 Update URI: https://github.com/a8cteam51/plugin-autoupdate-filter/


### PR DESCRIPTION
PHP didn't support union types in the function signature, so this was causing a fatal in PHP 7.4.

Have now tested the fix in PHP 7.4, 8.1, 8.2, 8.3