### PR TITLE
Apply delay to autoupdates

### DIFF
--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -139,6 +139,13 @@ class Plugin_Autoupdate_Filter {
 	 * @return bool True to update, false to not update.
 	 */
 	public function filter_enforce_delay( $update, $item ): bool {
+		// no delay if site is a canary site
+		$site_url = wp_parse_url( home_url(), PHP_URL_HOST );
+		if ( isset( $this->settings->canary_sites ) && in_array( $site_url, $this->settings->canary_sites, true ) ) {
+			return $update;
+		}
+
+		// otherwise add delay to plugin updates
 		if ( true === $update ) {
 			$helpers          = new Plugin_Autoupdate_Filter_Helpers();
 			$has_delay_passed = $helpers->has_delay_passed( $item->slug, $item->new_version );

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -138,7 +138,7 @@ class Plugin_Autoupdate_Filter {
 	 *
 	 * @return bool True to update, false to not update.
 	 */
-	public function filter_enforce_autoupdate_delay( $update, $item ): bool {
+	public function filter_enforce_delay( $update, $item ): bool {
 		if ( true === $update ) {
 			$helpers          = new Plugin_Autoupdate_Filter_Helpers();
 			$has_delay_passed = $helpers->has_delay_passed( $item->slug, $item->new_version );

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+require_once 'includes/class-plugin-autoupdate-filter-helpers.php';
+
 class Plugin_Autoupdate_Filter {
 
 	/**
@@ -36,6 +38,9 @@ class Plugin_Autoupdate_Filter {
 		// setup plugins and core to autoupdate _unless_ it's during specific day/time
 		add_filter( 'auto_update_plugin', array( $this, 'filter_auto_update_specific_times' ), 10, 2 );
 		add_filter( 'auto_update_core', array( $this, 'filter_auto_update_specific_times' ), 10, 2 );
+
+		// enforce a delay on all plugin autoupdates, based on release date
+		add_filter( 'auto_update_plugin', array( $this, 'filter_enforce_delay' ), 11, 2 );
 
 		// Replace automatic update wording on plugin management page in admin
 		add_filter( 'plugin_auto_update_setting_html', array( $this, 'filter_custom_setting_html' ), 11, 3 );
@@ -126,7 +131,27 @@ class Plugin_Autoupdate_Filter {
 	}
 
 	/**
-	 * Enable or disable plugin auto-updates based on time and day of the week.
+	 * Disable plugin auto-updates based on if a delay has passed since plugin was released.
+	 *
+	 * @param bool   $update Whether to update the plugin or not.
+	 * @param object $item   The plugin update object.
+	 *
+	 * @return bool True to update, false to not update.
+	 */
+	public function filter_enforce_autoupdate_delay( $update, $item ): bool {
+		if ( true === $update ) {
+			$helpers          = new Plugin_Autoupdate_Filter_Helpers();
+			$has_delay_passed = $helpers->has_delay_passed( $item->slug, $item->new_version );
+
+			if ( false === $has_delay_passed ) {
+				return false;
+			}
+		}
+		return $update;
+	}
+
+	/**
+	 * Disable auto-updates based on time and day of the week.
 	 *
 	 * @param bool   $update Whether to update the plugin or not.
 	 * @param object $item   The plugin update object.
@@ -134,7 +159,6 @@ class Plugin_Autoupdate_Filter {
 	 * @return bool True to update, false to not update.
 	 */
 	public function filter_auto_update_specific_times( $update, $item ): bool {
-
 		$holidays = array(
 			'christmas' => array(
 				'start' => gmdate( 'Y' ) . '-12-23 00:00:00',

--- a/includes/class-plugin-autoupdate-filter-helpers.php
+++ b/includes/class-plugin-autoupdate-filter-helpers.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Plugin Autoupdate Filter Helpers class
+ *
+ * @package Plugin_Autoupdate_Filter
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class Plugin_Autoupdate_Filter_Helpers {
+
+	/**
+	 * Determines whether a plugin should be updated based on release version and delay rules.
+	 *
+	 * @param string $plugin_slug Slug of the plugin.
+	 * @param string $update_version The version that the plugin would be updated to.
+	 * 
+	 * @return bool True if the plugin should be updated, false otherwise.
+	 */
+	public function has_delay_passed( string $plugin_slug, string $update_version ): bool {
+		// delay most plugins 2 days. delay woocommerce 7 days.
+		$delay_days        = 'woocommerce' === $plugin_slug ? 7 : 2;
+		$installed_version = $this->get_installed_plugin_version( $plugin_slug );
+
+		if ( empty( $installed_version ) || $update_version === $installed_version ) {
+			return false;
+		}
+
+		$installed_version_parts = explode( '.', $installed_version );
+		$update_version_parts    = explode( '.', $update_version );
+		
+		if ( 3 !== count( $installed_version_parts ) || 3 !== count( $update_version_parts ) ) {
+			return false;
+		}
+
+		// only apply delays to major and minor releases. let point releases (patches) go through.
+		if ( $installed_version_parts[0] !== $update_version_parts[0] || $installed_version_parts[1] !== $update_version_parts[1] ) {
+			$update_allowed_after = $this->get_delay_date( $plugin_slug, $update_version, $delay_days );
+
+			if ( time() >= $update_allowed_after ) {
+				$this->clear_plugin_delay( $plugin_slug );
+				return true;
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieve the current version of an installed plugin.
+	 *
+	 * @param string $plugin_slug Slug of the plugin.
+	 * 
+	 * @return string Current version of the plugin or an empty string if not found.
+	 */
+	public function get_installed_plugin_version( string $plugin_slug ): string {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$plugins = get_plugins();
+		foreach ( $plugins as $plugin_path => $plugin_info ) {
+			if ( $plugin_slug === dirname( $plugin_path ) ) {
+				return $plugin_info['Version'];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Retrieve the date after which a plugin update is allowed or calculate it if not set.
+	 *
+	 * @param string $plugin_slug Slug of the plugin.
+	 * @param string $update_version The version to update to.
+	 * @param int $delay_days Number of days to delay the update.
+	 * 
+	 * @return int The Unix timestamp indicating when the plugin can be updated.
+	 */
+	public function get_delay_date( string $plugin_slug, string $update_version, int $delay_days ): int {
+		$option_key = 'plugin_update_delays';
+		$delays     = get_option( $option_key, array() );
+
+		if ( ! isset( $delays[ $plugin_slug ][ $update_version ] ) ) {
+			$release_date = $this->get_plugin_release_date( $plugin_slug );
+
+			if ( ! $release_date ) {
+				$release_date = time();
+			}
+
+			$delays[ $plugin_slug ][ $update_version ] = strtotime( "+{$delay_days} days", $release_date );
+			update_option( $option_key, $delays );
+		}
+
+		return $delays[ $plugin_slug ][ $update_version ];
+	}
+
+	/**
+	 * Retrieve the release date of a plugin based on its slug.
+	 *
+	 * @param string $plugin_slug Slug of the plugin.
+	 * @return int The Unix timestamp of the release date or the current time if not available.
+	 */
+	public function get_plugin_release_date( string $plugin_slug ): int {
+		$response = wp_remote_get( "https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug={$plugin_slug}" );
+		
+		if ( is_wp_error( $response ) ) {
+			return time();
+		}
+
+		$plugin_info = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( isset( $plugin_info['last_updated'] ) ) {
+			return strtotime( $plugin_info['last_updated'] );
+		}
+
+		return time();
+	}
+
+	/**
+	 * Clear out the entry for the plugin in the serialized array.
+	 *
+	 * @param string $plugin_slug Slug of the plugin.
+	 * @return void
+	 */
+	public function clear_plugin_delay( string $plugin_slug ): void {
+		$option_key = 'plugin_update_delays';
+		$delays     = get_option( $option_key, array() );
+
+		if ( isset( $delays[ $plugin_slug ] ) ) {
+			unset( $delays[ $plugin_slug ] );
+			update_option( $option_key, $delays );
+		}
+	}
+}

--- a/includes/class-plugin-autoupdate-filter-helpers.php
+++ b/includes/class-plugin-autoupdate-filter-helpers.php
@@ -16,7 +16,7 @@ class Plugin_Autoupdate_Filter_Helpers {
 	 *
 	 * @param string $plugin_slug Slug of the plugin.
 	 * @param string $update_version The version that the plugin would be updated to.
-	 * 
+	 *
 	 * @return bool True if the plugin should be updated, false otherwise.
 	 */
 	public function has_delay_passed( string $plugin_slug, string $update_version ): bool {
@@ -30,7 +30,7 @@ class Plugin_Autoupdate_Filter_Helpers {
 
 		$installed_version_parts = explode( '.', $installed_version );
 		$update_version_parts    = explode( '.', $update_version );
-		
+
 		if ( 3 !== count( $installed_version_parts ) || 3 !== count( $update_version_parts ) ) {
 			return false;
 		}
@@ -54,7 +54,7 @@ class Plugin_Autoupdate_Filter_Helpers {
 	 * Retrieve the current version of an installed plugin.
 	 *
 	 * @param string $plugin_slug Slug of the plugin.
-	 * 
+	 *
 	 * @return string Current version of the plugin or an empty string if not found.
 	 */
 	public function get_installed_plugin_version( string $plugin_slug ): string {
@@ -64,7 +64,7 @@ class Plugin_Autoupdate_Filter_Helpers {
 
 		$plugins = get_plugins();
 		foreach ( $plugins as $plugin_path => $plugin_info ) {
-			if ( $plugin_slug === dirname( $plugin_path ) ) {
+			if ( dirname( $plugin_path ) === $plugin_slug ) {
 				return $plugin_info['Version'];
 			}
 		}
@@ -78,7 +78,7 @@ class Plugin_Autoupdate_Filter_Helpers {
 	 * @param string $plugin_slug Slug of the plugin.
 	 * @param string $update_version The version to update to.
 	 * @param int $delay_days Number of days to delay the update.
-	 * 
+	 *
 	 * @return int The Unix timestamp indicating when the plugin can be updated.
 	 */
 	public function get_delay_date( string $plugin_slug, string $update_version, int $delay_days ): int {
@@ -107,7 +107,7 @@ class Plugin_Autoupdate_Filter_Helpers {
 	 */
 	public function get_plugin_release_date( string $plugin_slug ): int {
 		$response = wp_remote_get( "https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug={$plugin_slug}" );
-		
+
 		if ( is_wp_error( $response ) ) {
 			return time();
 		}

--- a/includes/class-plugin-autoupdate-filter-helpers.php
+++ b/includes/class-plugin-autoupdate-filter-helpers.php
@@ -31,10 +31,6 @@ class Plugin_Autoupdate_Filter_Helpers {
 		$installed_version_parts = explode( '.', $installed_version );
 		$update_version_parts    = explode( '.', $update_version );
 
-		if ( 3 !== count( $installed_version_parts ) || 3 !== count( $update_version_parts ) ) {
-			return false;
-		}
-
 		// only apply delays to major and minor releases. let point releases (patches) go through.
 		if ( $installed_version_parts[0] !== $update_version_parts[0] || $installed_version_parts[1] !== $update_version_parts[1] ) {
 			$update_allowed_after = $this->get_delay_date( $plugin_slug, $update_version, $delay_days );

--- a/includes/class-plugin-autoupdate-filter-helpers.php
+++ b/includes/class-plugin-autoupdate-filter-helpers.php
@@ -20,8 +20,13 @@ class Plugin_Autoupdate_Filter_Helpers {
 	 * @return bool True if the plugin should be updated, false otherwise.
 	 */
 	public function has_delay_passed( string $plugin_slug, string $update_version ): bool {
-		// delay most plugins 2 days. delay woocommerce 7 days.
-		$delay_days        = 'woocommerce' === $plugin_slug ? 7 : 2;
+		// delay most plugins 2 days. delay some plugins 7 days.
+		$longer_delay_plugins = array(
+			'woocommerce',
+			'woocommerce-payments',
+		);
+
+		$delay_days        = in_array( $plugin_slug, $longer_delay_plugins, true ) ? 7 : 2;
 		$installed_version = $this->get_installed_plugin_version( $plugin_slug );
 
 		if ( empty( $installed_version ) || $update_version === $installed_version ) {

--- a/includes/class-plugin-autoupdate-filter-helpers.php
+++ b/includes/class-plugin-autoupdate-filter-helpers.php
@@ -115,7 +115,7 @@ class Plugin_Autoupdate_Filter_Helpers {
 
 		$plugin_info = json_decode( wp_remote_retrieve_body( $response ), true );
 		if ( isset( $plugin_info['last_updated'] ) ) {
-			return strtotime( $plugin_info['last_updated'] );
+			return strtotime( $plugin_info['last_updated'] ) ?? time();
 		}
 
 		return time();

--- a/includes/class-plugin-autoupdate-filter-helpers.php
+++ b/includes/class-plugin-autoupdate-filter-helpers.php
@@ -106,7 +106,7 @@ class Plugin_Autoupdate_Filter_Helpers {
 	 * @return int The Unix timestamp of the release date or the current time if not available.
 	 */
 	public function get_plugin_release_date( string $plugin_slug ): int {
-		$response = wp_remote_get( "https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug={$plugin_slug}" );
+		$response = wp_safe_remote_get( "https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug={$plugin_slug}" );
 
 		if ( is_wp_error( $response ) ) {
 			return time();

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -3,7 +3,7 @@
 Plugin Name: Plugin Autoupdate Filter
 Plugin URI: https://github.com/a8cteam51/plugin-autoupdate-filter
 Description: Filters whether autoupdates are on based on day/time and other settings.
-Version: 1.5.3
+Version: 1.6.0
 Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 Update URI: https://github.com/a8cteam51/plugin-autoupdate-filter/


### PR DESCRIPTION
## Changes in this pull request

Applies a 2 day delay to all major and minor plugin autoupdates (7 days for WooCommerce).

## Details

- Point releases (patches) can proceed without delay, as long as the major and minor versions match
- Delay is based on release date, as per the WordPress.org plugin repository API
- If no release date is available (e.g. plugin is hosted elsewhere), then the date that the update is first checked is used
- Dates are stored in WordPress option, then cleared after plugin is updated
- The new filter only adds a delay to autoupdates that would otherwise happen. It never forces an autoupdate to be true.

## To test

1. Load some out-of-date plugins on your test site, some that are a single point release behind, some that are a major or minor release behind.
2. Make sure that you are in the normal update times of the Plugin Autoupdate Filter (US East Coast business hours, for the most part)
3. Open a shell for your test site, and run `wp cron event run wp_update_plugins` (note that I've seen there be a delay for this to function as you would expect; it's not instant)
4. Verify that plugins didn't update that are within the delay period, and also they stored a date in the options
5. Verify that plugins did update that are past their delay period, or are only point releases

## Review

- I've created a new `helpers` class and file, and am loading a lot of functionality from there. Please take a look and make sure that I'm referencing that right. General observations around best practices, or readability, etc. are welcome.
- Trying to follow team51 best practices. Any suggestions around that are welcome (be aware this is a public repo)

Note: We won't merge anything until the team decides this is for sure the direction we want to go.