### PR TITLE
Define settings property

### DIFF
--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -12,6 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Plugin_Autoupdate_Filter {
 
 	/**
+	 * @var stdClass Holds the settings
+	 */
+	private $settings;
+
+	/**
 	 * Initialize WordPress hooks
 	 */
 	public function init(): void {


### PR DESCRIPTION
Creation of dynamic properties within a class is deprecated in recent versions of PHP. To resolve this issue, we are defining the settings property within the Plugin_Autoupdate_Filter class.

Mentions #34 