### PR TITLE
Protect against null version

### DIFF
--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -153,7 +153,8 @@ class Plugin_Autoupdate_Filter {
 		// otherwise add delay to plugin updates
 		if ( true === $update ) {
 			$helpers          = new Plugin_Autoupdate_Filter_Helpers();
-			$has_delay_passed = $helpers->has_delay_passed( $item->slug, $item->new_version );
+			$new_version      = $item->new_version ?? '0.0.0'; // protect against null
+			$has_delay_passed = $helpers->has_delay_passed( $item->slug, $new_version );
 
 			if ( false === $has_delay_passed ) {
 				return false;

--- a/includes/class-plugin-autoupdate-filter-helpers.php
+++ b/includes/class-plugin-autoupdate-filter-helpers.php
@@ -29,7 +29,7 @@ class Plugin_Autoupdate_Filter_Helpers {
 		$delay_days        = in_array( $plugin_slug, $longer_delay_plugins, true ) ? 7 : 2;
 		$installed_version = $this->get_installed_plugin_version( $plugin_slug );
 
-		if ( empty( $installed_version ) || $update_version === $installed_version ) {
+		if ( empty( $installed_version ) || $update_version === $installed_version || '0.0.0' === $update_version ) {
 			return false;
 		}
 

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -3,7 +3,7 @@
 Plugin Name: Plugin Autoupdate Filter
 Plugin URI: https://github.com/a8cteam51/plugin-autoupdate-filter
 Description: Filters whether autoupdates are on based on day/time and other settings.
-Version: 1.6.0
+Version: 1.6.1
 Author: WordPress.com Special Projects
 Author URI: https://wpspecialprojects.wordpress.com/
 Update URI: https://github.com/a8cteam51/plugin-autoupdate-filter/


### PR DESCRIPTION
If version isn't returned, we shouldn't be updating anyway, so we'll protect against a null version, and then return false for updating if we don't have a version.

Closes #36 