### PR TITLE
Protect against null slug

### DIFF
--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -153,8 +153,9 @@ class Plugin_Autoupdate_Filter {
 		// otherwise add delay to plugin updates
 		if ( true === $update ) {
 			$helpers          = new Plugin_Autoupdate_Filter_Helpers();
+			$slug             = $item->slug ?? 'no-slug'; // protect against null
 			$new_version      = $item->new_version ?? '0.0.0'; // protect against null
-			$has_delay_passed = $helpers->has_delay_passed( $item->slug, $new_version );
+			$has_delay_passed = $helpers->has_delay_passed( $slug, $new_version );
 
 			if ( false === $has_delay_passed ) {
 				return false;


### PR DESCRIPTION
As it turns out, some plugins can return a null slug and a null version. For example, 

```
stdClass Object
(
    [id] => automatewoo-order-rule-recent-failed-orders/automatewoo-order-rule-recent-failed-orders.php
    [slug] => 
    [plugin] => automatewoo-order-rule-recent-failed-orders/automatewoo-order-rule-recent-failed-orders.php
    [new_version] => 
    [url] => 
    [package] => 
  ...
```

So this just protects against a null slug.