### PR TITLE
Some plugins are not updating and keep adding a 2 day delay

### DIFF
--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -166,16 +166,6 @@ class Plugin_Autoupdate_Filter {
 			}
 		}
 
-		// Make sure the plugin is included in auto-updates (on vs off).
-		if ( true === $update ) {
-			$auto_updates = get_site_option( 'auto_update_plugins', array() );
-
-			if ( ! in_array( $plugin_file, $auto_updates ) ) {
-				$auto_updates[] = $plugin_file;
-				update_site_option('auto_update_plugins', $auto_updates);
-			}
-		}
-
 		return $update;
 	}
 

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -163,6 +163,16 @@ class Plugin_Autoupdate_Filter {
 			}
 		}
 
+		// Make sure the plugin is included in auto-updates.
+		if ( true === $update ) {
+			$auto_updates = get_site_option( 'auto_update_plugins', array() );
+
+			if ( ! in_array( $plugin_file, $auto_updates ) ) {
+				$auto_updates[] = $plugin_file;
+				update_site_option('auto_update_plugins', $auto_updates);
+			}
+		}
+
 		return $update;
 	}
 

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -71,7 +71,7 @@ class Plugin_Autoupdate_Filter {
 		add_action( 'admin_init', array( $this, 'output_auto_updates_disabled_admin_notice' ) );
 
 		// Clean-up delay data after a plugin is updated
-		add_action('upgrader_process_complete', array( $this, 'cleanup_plugin_delay_after_update_complete' ), 10, 2 );
+		add_action( 'upgrader_process_complete', array( $this, 'cleanup_plugin_delay_after_update_complete' ), 10, 2 );
 	}
 
 	/**

--- a/includes/class-plugin-autoupdate-filter-helpers.php
+++ b/includes/class-plugin-autoupdate-filter-helpers.php
@@ -56,7 +56,6 @@ class Plugin_Autoupdate_Filter_Helpers {
 			$update_allowed_after = $this->get_delay_date( $plugin_slug, $plugin_new_version, $delay_days, $plugin_file );
 
 			if ( time() >= $update_allowed_after ) {
-				$this->clear_plugin_delay( $plugin_file );
 				return true;
 			}
 

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -12,7 +12,7 @@
  * Plugin URI:      https://github.com/a8cteam51/plugin-autoupdate-filter
  * Update URI:      https://github.com/a8cteam51/plugin-autoupdate-filter
  * Description:     Filters whether autoupdates are on based on day/time and other settings.
- * Version:         1.6.3
+ * Version:         1.6.4
  * Requires PHP:    7.4
  * Author:          WordPress.com Special Projects
  * Author URI:      https://wpspecialprojects.wordpress.com


### PR DESCRIPTION
## Changes in this Pull Request

- Running `wp plugin list` might return a list of plugins with `auto_update` set to `off`. This PR ensures that, if `$update` is `true`, the plugin filename is populated in the list of `auto_update_plugins`, resulting in an `on` value.

- For cases where the plugin `slug` is not found on the Dotorg repo ([example](https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=woocommerce-com-affiliate-for-woocommerce)), a new delay of `time() + 2 days` is avoided by cleaning the delay data after the plugin has updated, as opposed to when the delay has already passed.

Context in [Slack](https://a8c.slack.com/archives/C018UMRUN3V/p1723645058778119).

https://github.com/a8cteam51/team51-dev-requests/issues/4730