### PR TITLE
Add delay message

### DIFF
--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -161,7 +161,25 @@ class Plugin_Autoupdate_Filter {
 			$plugin_new_version = empty( $item->new_version ) ? '0.0.0' : $item->new_version;
 
 			$has_delay_passed = $helpers->has_delay_passed( $plugin_slug, $plugin_new_version, $plugin_file );
+
 			if ( false === $has_delay_passed ) {
+				$option_key = 'plugin_update_delays';
+				$delays     = get_option( $option_key, array() );
+				$delay_date = $delays[ $plugin_file ][ $plugin_new_version ];
+
+				// Get the site's date and time format settings.
+				$datetime_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
+				$formatted_date  = date_i18n( $datetime_format, $delay_date );
+				
+				// adds message to update notice box for that plugin on the plugins page
+				add_filter(
+					"in_plugin_update_message-{$plugin_file}",
+					function() use ( $plugin_new_version, $formatted_date ) {
+						echo ' Autoupdate to ' . $plugin_new_version . ' will be delayed until after ' . $formatted_date . ' UTC.' ;
+					},
+					10,
+					2
+				);
 				$update = false;
 			}
 		}

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -170,12 +170,12 @@ class Plugin_Autoupdate_Filter {
 				// Get the site's date and time format settings.
 				$datetime_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
 				$formatted_date  = date_i18n( $datetime_format, $delay_date );
-				
+
 				// adds message to update notice box for that plugin on the plugins page
 				add_filter(
 					"in_plugin_update_message-{$plugin_file}",
 					function() use ( $plugin_new_version, $formatted_date ) {
-						echo ' Autoupdate to ' . $plugin_new_version . ' will be delayed until after ' . $formatted_date . ' UTC.' ;
+						echo ' Autoupdate to ' . esc_html( $plugin_new_version ) . ' will be delayed until after ' . esc_html( $formatted_date ) . ' UTC.';
 					},
 					10,
 					2

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -169,7 +169,7 @@ class Plugin_Autoupdate_Filter {
 		if ( false === $has_delay_passed ) {
 			$option_key = 'plugin_update_delays';
 			$delays     = get_option( $option_key, array() );
-			if ( isset( $delays[ $plugin_file ][ $plugin_new_version ] ) ) {
+			if ( isset( $delays[ $plugin_file ][ $plugin_new_version ] ) && is_numeric( $delays[ $plugin_file ][ $plugin_new_version ] ) ) {
 				$delay_date = $delays[ $plugin_file ][ $plugin_new_version ];
 
 				// Get the site's date and time format settings.

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -152,7 +152,7 @@ class Plugin_Autoupdate_Filter {
 			return $update;
 		}
 
-		// otherwise add delay to plugin updates
+		// otherwise apply delay logic
 		if ( true === $update ) {
 			$helpers = new Plugin_Autoupdate_Filter_Helpers();
 
@@ -165,21 +165,23 @@ class Plugin_Autoupdate_Filter {
 			if ( false === $has_delay_passed ) {
 				$option_key = 'plugin_update_delays';
 				$delays     = get_option( $option_key, array() );
-				$delay_date = $delays[ $plugin_file ][ $plugin_new_version ];
+				if ( isset( $delays[ $plugin_file ][ $plugin_new_version ] ) ) {
+					$delay_date = $delays[ $plugin_file ][ $plugin_new_version ];
 
-				// Get the site's date and time format settings.
-				$datetime_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
-				$formatted_date  = date_i18n( $datetime_format, $delay_date );
+					// Get the site's date and time format settings.
+					$datetime_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
+					$formatted_date  = date_i18n( $datetime_format, $delay_date );
 
-				// adds message to update notice box for that plugin on the plugins page
-				add_filter(
-					"in_plugin_update_message-{$plugin_file}",
-					function() use ( $plugin_new_version, $formatted_date ) {
-						echo ' Autoupdate to ' . esc_html( $plugin_new_version ) . ' will be delayed until after ' . esc_html( $formatted_date ) . ' UTC.';
-					},
-					10,
-					2
-				);
+					// adds message to update notice box for that plugin on the plugins page
+					add_filter(
+						"in_plugin_update_message-{$plugin_file}",
+						function() use ( $plugin_new_version, $formatted_date ) {
+							echo ' For stability, autoupdates operate on a slight delay. Autoupdate to ' . esc_html( $plugin_new_version ) . ' is currently estimated to run after ' . esc_html( $formatted_date ) . ' UTC.';
+						},
+						10,
+						2
+					);
+				}
 				$update = false;
 			}
 		}

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -174,7 +174,8 @@ class Plugin_Autoupdate_Filter {
 
 				// Get the site's date and time format settings.
 				$datetime_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
-				$formatted_date  = date_i18n( $datetime_format, $delay_date );
+				// Set the $gmt parameter to true for UTC time
+				$formatted_date = date_i18n( $datetime_format, $delay_date, true );
 
 				// adds message to update notice box for that plugin on the plugins page
 				add_filter(

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -146,6 +146,11 @@ class Plugin_Autoupdate_Filter {
 	 * @return bool True to update, false to not update.
 	 */
 	public function filter_enforce_delay( $update, $item ): bool {
+		// protect against non-bool being returned from this function
+		if ( null === $update ) {
+			$update = false;
+		}
+
 		// no delay if site is a canary site
 		$site_url = wp_parse_url( home_url(), PHP_URL_HOST );
 		if ( isset( $this->settings->canary_sites ) && in_array( $site_url, $this->settings->canary_sites, true ) ) {
@@ -153,37 +158,35 @@ class Plugin_Autoupdate_Filter {
 		}
 
 		// otherwise apply delay logic
-		if ( true === $update ) {
-			$helpers = new Plugin_Autoupdate_Filter_Helpers();
+		$helpers = new Plugin_Autoupdate_Filter_Helpers();
 
-			$plugin_file        = empty( $item->plugin ) ? '' : $item->plugin;
-			$plugin_slug        = empty( $item->slug ) ? '' : $item->slug;
-			$plugin_new_version = empty( $item->new_version ) ? '0.0.0' : $item->new_version;
+		$plugin_file        = empty( $item->plugin ) ? '' : $item->plugin;
+		$plugin_slug        = empty( $item->slug ) ? '' : $item->slug;
+		$plugin_new_version = empty( $item->new_version ) ? '0.0.0' : $item->new_version;
 
-			$has_delay_passed = $helpers->has_delay_passed( $plugin_slug, $plugin_new_version, $plugin_file );
+		$has_delay_passed = $helpers->has_delay_passed( $plugin_slug, $plugin_new_version, $plugin_file );
 
-			if ( false === $has_delay_passed ) {
-				$option_key = 'plugin_update_delays';
-				$delays     = get_option( $option_key, array() );
-				if ( isset( $delays[ $plugin_file ][ $plugin_new_version ] ) ) {
-					$delay_date = $delays[ $plugin_file ][ $plugin_new_version ];
+		if ( false === $has_delay_passed ) {
+			$option_key = 'plugin_update_delays';
+			$delays     = get_option( $option_key, array() );
+			if ( isset( $delays[ $plugin_file ][ $plugin_new_version ] ) ) {
+				$delay_date = $delays[ $plugin_file ][ $plugin_new_version ];
 
-					// Get the site's date and time format settings.
-					$datetime_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
-					$formatted_date  = date_i18n( $datetime_format, $delay_date );
+				// Get the site's date and time format settings.
+				$datetime_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
+				$formatted_date  = date_i18n( $datetime_format, $delay_date );
 
-					// adds message to update notice box for that plugin on the plugins page
-					add_filter(
-						"in_plugin_update_message-{$plugin_file}",
-						function() use ( $plugin_new_version, $formatted_date ) {
-							echo ' For stability, autoupdates operate on a slight delay. Autoupdate to ' . esc_html( $plugin_new_version ) . ' is currently estimated to run after ' . esc_html( $formatted_date ) . ' UTC.';
-						},
-						10,
-						2
-					);
-				}
-				$update = false;
+				// adds message to update notice box for that plugin on the plugins page
+				add_filter(
+					"in_plugin_update_message-{$plugin_file}",
+					function() use ( $plugin_new_version, $formatted_date ) {
+						echo ' For stability, autoupdates operate on a slight delay. Autoupdate to version ' . esc_html( $plugin_new_version ) . ' is currently estimated to run after ' . esc_html( $formatted_date ) . ' UTC.';
+					},
+					10,
+					2
+				);
 			}
+			$update = false;
 		}
 
 		return $update;

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -5,6 +5,8 @@
  * @package Plugin_Autoupdate_Filter
  */
 
+use AutomateWoo\Error;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
@@ -169,7 +171,7 @@ class Plugin_Autoupdate_Filter {
 		if ( false === $has_delay_passed ) {
 			$option_key = 'plugin_update_delays';
 			$delays     = get_option( $option_key, array() );
-			if ( isset( $delays[ $plugin_file ][ $plugin_new_version ] ) && is_numeric( $delays[ $plugin_file ][ $plugin_new_version ] ) ) {
+			if ( isset( $delays[ $plugin_file ][ $plugin_new_version ] ) && is_numeric( $delays[ $plugin_file ][ $plugin_new_version ] ) && ( ! empty( $plugin_file ) && is_plugin_active( $plugin_file ) ) ) {
 				$delay_date = $delays[ $plugin_file ][ $plugin_new_version ];
 
 				// Get the site's date and time format settings.
@@ -180,8 +182,10 @@ class Plugin_Autoupdate_Filter {
 				// adds message to update notice box for that plugin on the plugins page
 				add_filter(
 					"in_plugin_update_message-{$plugin_file}",
-					function() use ( $plugin_new_version, $formatted_date ) {
-						echo ' For stability, autoupdates operate on a slight delay. Autoupdate to version ' . esc_html( $plugin_new_version ) . ' is currently estimated to run after ' . esc_html( $formatted_date ) . ' UTC.';
+					function( $plugin_data, $response ) use ( $plugin_new_version, $formatted_date ) {
+						if ( ! empty( $response->package ) ) {
+							echo ' For stability, autoupdates operate on a slight delay. Autoupdate to version ' . esc_html( $plugin_new_version ) . ' is currently estimated to run after ' . esc_html( $formatted_date ) . ' UTC.';
+						}
 					},
 					10,
 					2


### PR DESCRIPTION
Adds delay message to the update message box for each eligible plugin on the plugins page.
Displays date in format as set in the site settings, in UTC.

<img width="1221" alt="Screenshot 2024-10-10 at 12 39 40" src="https://github.com/user-attachments/assets/43e4a718-515e-41c9-a6e3-760b5e2e0531">
