### PR TITLE
Ensure plugin init() runs on WP init and not before

### DIFF
--- a/class-plugin-autoupdate-filter-self-update.php
+++ b/class-plugin-autoupdate-filter-self-update.php
@@ -72,5 +72,5 @@ class Plugin_Autoupdate_Filter_Self_Update {
 		);
 	}
 }
-$plugin_autoupdate_filter_self_update = new Plugin_Autoupdate_Filter_Self_Update();
-$plugin_autoupdate_filter_self_update->init();
+
+add_action( 'init', array( new Plugin_Autoupdate_Filter_Self_Update(), 'init' ) );

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -390,5 +390,4 @@ class Plugin_Autoupdate_Filter {
 		}
 	}
 }
-$plugin_autoupdate_filter = new Plugin_Autoupdate_Filter();
-$plugin_autoupdate_filter->init();
+add_action( 'init', array( new Plugin_Autoupdate_Filter(), 'init' ) );

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -390,4 +390,5 @@ class Plugin_Autoupdate_Filter {
 		}
 	}
 }
+
 add_action( 'init', array( new Plugin_Autoupdate_Filter(), 'init' ) );


### PR DESCRIPTION
When the plugin is installed on site that doesn't have the required transient option filled, it causes the fatal error:

```
'PHP Fatal error:  Uncaught Error: Call to undefined function wp_validate_redirect() in /var/www/html/wp-includes/http.php:655\n' +
      'Stack trace:\n' +
      "#0 /var/www/html/wp-includes/class-wp-hook.php(326): allowed_http_request_hosts(false, 'opsoasis.wpspec...')\n" +
      '#1 /var/www/html/wp-includes/plugin.php(205): WP_Hook->apply_filters(false, Array)\n' +
      "#2 /var/www/html/wp-includes/http.php(607): apply_filters('http_request_ho...', false, 'opsoasis.wpspec...', 'https://opsoasi...')\n" +
      "#3 /var/www/html/wp-includes/class-wp-http.php(280): wp_http_validate_url('https://opsoasi...')\n" +
      "#4 /var/www/html/wp-includes/class-wp-http.php(651): WP_Http->request('https://opsoasi...', Array)\n" +
      "#5 /var/www/html/wp-includes/http.php(80): WP_Http->get('https://opsoasi...', Array)\n" +
      "#6 /var/www/html/wp-content/plugins/plugin-autoupdate-filter-1.6.1/class-plugin-autoupdate-filter.php(85): wp_safe_remote_get('https://opsoasi...', Array)\n" +
      '#7 /var/www/html/wp-content/plugins/plugin-autoupdate-filter-1.6.1/class-plugin-autoupdate-filter.php(28): Plugin_Autoupdate_Filter->get_auto_update_settings()\n' +
      '#8 /var/www/html/wp-content/plugins/plugin-autoupdate-filter-1.6.1/class-plugin-autoupdate-filter.php(343): Plugin_Autoupdate_Filter->init()\n' +
      "#9 /var/www/html/wp-content/plugins/plugin-autoupdate-filter-1.6.1/plugin-autoupdate-filter.php(25): require_once('/var/www/html/w...')\n" +
      "#10 /var/www/html/wp-settings.php(526): include_once('/var/www/html/w...')\n" +
      "#11 /var/www/html/wp-config.php(90): require_once('/var/www/html/w...')\n" +
      "#12 /var/www/html/wp-load.php(50): require_once('/var/www/html/w...')\n" +
      "#13 /internal/eval.php(2): require_once('/var/www/html/w...')\n" +
      '#14 {main}\n' +
      '  thrown in /var/www/html/wp-includes/http.php on line 655\n'
  },
```
Steps to reproduce:

1. Create the Studio site
2. Install the latest version of the plugin and activate it
3. Remove option:
```
wp option delete _transient_wpcpmsp_auto_update_settings
```
4. Refresh WP Admin

I propose to fix that by running the plugin's `init()` logic on the WP `init` action.

