### PR TITLE
Add centralized settings support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ By default, the plugin always returns `true` for autoupdates Mon-Thu 6am-7pm Eas
 
 ### Centralized settings
 
-By default, this plugin checks an endpoint set up by the WordPress Special Projects team to get centralized settings. If you use this plugin and aren't part of the team, then we recommend you either set up your own endpoint or remove that portion of the code. 
+By default, this plugin checks an endpoint set up by the WordPress Special Projects team to get centralized settings. If you use this plugin and aren't part of the team, then we recommend you either set up your own endpoint or remove that portion of the code.
+
+The payload supports:
+
+- `disable_all` to disable all automatic updates.
+- `canary_sites` to bypass release-delay behavior for selected sites.
+- `disabled_plugins` to disable automatic updates for specific plugins across connected sites.
 
 ## Support
 

--- a/class-plugin-autoupdate-filter.php
+++ b/class-plugin-autoupdate-filter.php
@@ -138,7 +138,15 @@ class Plugin_Autoupdate_Filter {
 	 */
 	public function filter_maybe_disable_all_autoupdates( $update, $item ): bool {
 
-		if ( isset( $this->settings->disable_all ) || null === $update ) {
+		if ( isset( $this->settings->disable_all ) && true === $this->settings->disable_all ) {
+			return false;
+		}
+
+		if ( is_object( $item ) && $this->is_plugin_disabled_in_centralized_settings( $item ) ) {
+			return false;
+		}
+
+		if ( null === $update ) {
 			return false;
 		}
 
@@ -311,17 +319,21 @@ class Plugin_Autoupdate_Filter {
 			return $html . $toggle_link_html;
 		}
 
-		// check if updates are explicitly blocked for this plugin
-		if ( function_exists( 'disable_autoupdate_specific_plugins' ) ) {
+		$plugin_slug = dirname( $plugin_file );
+		if ( is_array( $plugin_data ) && isset( $plugin_data['TextDomain'] ) && is_string( $plugin_data['TextDomain'] ) && '' !== $plugin_data['TextDomain'] ) {
+			$plugin_slug = sanitize_key( $plugin_data['TextDomain'] );
+		}
 
-			// create a fake object to feed to disable_autoupdate_specific_plugins
-			$plugin_obj                    = new stdClass();
-			$plugin_obj->slug              = dirname( $plugin_file );
-			$plugin_allowed_to_update_bool = disable_autoupdate_specific_plugins( true, $plugin_obj );
+		$plugin_obj         = new stdClass();
+		$plugin_obj->slug   = $plugin_slug;
+		$plugin_obj->plugin = $plugin_file;
 
-			if ( false === $plugin_allowed_to_update_bool ) {
-				return 'Autoupdates have been explicitly deactivated for this plugin.' . $toggle_link_html;
-			}
+		if ( $this->is_plugin_disabled_by_centralized_settings( $plugin_obj ) ) {
+			return 'Autoupdates have been explicitly deactivated for this plugin via global OpsOasis settings.';
+		}
+
+		if ( $this->is_plugin_blocked_from_autoupdates( $plugin_obj ) ) {
+			return 'Autoupdates have been explicitly deactivated for this plugin.' . $toggle_link_html;
 		}
 
 		return 'Automatic updates managed by <strong>Plugin Autoupdate Filter</strong>' . $toggle_link_html;
@@ -514,21 +526,20 @@ class Plugin_Autoupdate_Filter {
 	 */
 	public function output_upgrade_message_for_specific_plugins(): void {
 
-		// check if updates are explicitly blocked for this plugin
 		// don't show if we are already disabling all updates
-		if ( ! function_exists( 'disable_autoupdate_specific_plugins' ) || isset( $this->settings->disable_all ) ) {
+		if ( isset( $this->settings->disable_all ) && true === $this->settings->disable_all ) {
 			return;
 		}
 
 		$all_plugins = get_plugins();
 
 		foreach ( $all_plugins as $plugin_file => $plugin_data ) {
-			// create a fake object to feed to disable_autoupdate_specific_plugins
-			$plugin_obj                    = new stdClass();
-			$slug                          = dirname( $plugin_file );
-			$plugin_obj->slug              = $slug;
-			$plugin_allowed_to_update_bool = disable_autoupdate_specific_plugins( true, $plugin_obj );
-			if ( false === $plugin_allowed_to_update_bool ) {
+			$plugin_obj         = new stdClass();
+			$slug               = dirname( $plugin_file );
+			$plugin_obj->slug   = $slug;
+			$plugin_obj->plugin = $plugin_file;
+
+			if ( $this->is_plugin_blocked_from_autoupdates( $plugin_obj ) ) {
 				// add notice next to the "update now" link
 				add_filter(
 					"in_plugin_update_message-{$plugin_file}",
@@ -554,13 +565,144 @@ class Plugin_Autoupdate_Filter {
 	}
 
 	/**
+	 * Determine if a plugin is allowed to autoupdate via external callback.
+	 *
+	 * @param stdClass $plugin_obj Plugin object with slug and/or plugin fields.
+	 *
+	 * @return bool
+	 */
+	private function is_plugin_allowed_to_autoupdate( stdClass $plugin_obj ): bool {
+		if ( ! function_exists( 'disable_autoupdate_specific_plugins' ) ) {
+			return true;
+		}
+
+		return (bool) call_user_func( 'disable_autoupdate_specific_plugins', true, $plugin_obj );
+	}
+
+	/**
+	 * Determine whether a plugin is disabled by centralized settings.
+	 *
+	 * @param stdClass $plugin_obj Plugin object with slug and/or plugin fields.
+	 *
+	 * @return bool
+	 */
+	private function is_plugin_disabled_by_centralized_settings( stdClass $plugin_obj ): bool {
+		$disabled_plugins = $this->get_centrally_disabled_plugins();
+		if ( empty( $disabled_plugins ) ) {
+			return false;
+		}
+
+		$plugin_file = '';
+		if ( isset( $plugin_obj->plugin ) && is_string( $plugin_obj->plugin ) ) {
+			$plugin_file = plugin_basename( $plugin_obj->plugin );
+		}
+
+		$plugin_slug = '';
+		if ( isset( $plugin_obj->slug ) && is_string( $plugin_obj->slug ) ) {
+			$plugin_slug = sanitize_key( $plugin_obj->slug );
+		}
+
+		if ( '' === $plugin_slug && '' !== $plugin_file ) {
+			$plugin_slug = sanitize_key( dirname( $plugin_file ) );
+		}
+
+		foreach ( $disabled_plugins as $disabled_plugin_file ) {
+			$disabled_plugin_slug = sanitize_key( dirname( $disabled_plugin_file ) );
+			if ( false === strpos( $disabled_plugin_file, '/' ) ) {
+				$disabled_plugin_slug = sanitize_key( $disabled_plugin_file );
+			}
+
+			if ( '' !== $plugin_file && $plugin_file === $disabled_plugin_file ) {
+				return true;
+			}
+
+			if ( '' !== $plugin_slug && $plugin_slug === $disabled_plugin_slug ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine whether a plugin is blocked from autoupdates.
+	 *
+	 * @param stdClass $plugin_obj Plugin object with slug and/or plugin fields.
+	 *
+	 * @return bool
+	 */
+	private function is_plugin_blocked_from_autoupdates( stdClass $plugin_obj ): bool {
+		if ( ! $this->is_plugin_allowed_to_autoupdate( $plugin_obj ) ) {
+			return true;
+		}
+
+		return $this->is_plugin_disabled_by_centralized_settings( $plugin_obj );
+	}
+
+	/**
+	 * Get normalized centrally disabled plugin identifiers.
+	 *
+	 * @return array
+	 */
+	private function get_centrally_disabled_plugins(): array {
+		if ( ! isset( $this->settings->disabled_plugins ) || ! is_array( $this->settings->disabled_plugins ) ) {
+			return array();
+		}
+
+		$normalized_plugins = array();
+		foreach ( $this->settings->disabled_plugins as $disabled_plugin ) {
+			if ( ! is_string( $disabled_plugin ) ) {
+				continue;
+			}
+
+			$disabled_plugin = plugin_basename( sanitize_text_field( $disabled_plugin ) );
+			if ( '' === $disabled_plugin || '.' === $disabled_plugin ) {
+				continue;
+			}
+
+			$normalized_plugins[] = $disabled_plugin;
+		}
+
+		return array_values( array_unique( $normalized_plugins ) );
+	}
+
+	/**
+	 * Determine whether centralized settings disable autoupdates for this item.
+	 *
+	 * @param object $item Plugin/theme/core item from update filter.
+	 *
+	 * @return bool
+	 */
+	private function is_plugin_disabled_in_centralized_settings( $item ): bool {
+		if ( isset( $item->theme ) ) {
+			return false;
+		}
+
+		$plugin_obj = new stdClass();
+
+		if ( isset( $item->plugin ) && is_string( $item->plugin ) ) {
+			$plugin_obj->plugin = $item->plugin;
+		}
+
+		if ( isset( $item->slug ) && is_string( $item->slug ) ) {
+			$plugin_obj->slug = $item->slug;
+		}
+
+		if ( ! isset( $plugin_obj->plugin ) && ! isset( $plugin_obj->slug ) ) {
+			return false;
+		}
+
+		return $this->is_plugin_disabled_by_centralized_settings( $plugin_obj );
+	}
+
+	/**
 	 * Autoupdates disabled admin notice
 	 *
 	 */
 	public function output_auto_updates_disabled_admin_notice(): void {
 		// add notice to the top of the screen
 		global $pagenow;
-		if ( 'plugins.php' === $pagenow && isset( $this->settings->disable_all ) ) {
+		if ( 'plugins.php' === $pagenow && isset( $this->settings->disable_all ) && true === $this->settings->disable_all ) {
 			add_action(
 				'admin_notices',
 				function() {

--- a/plugin-autoupdate-filter.php
+++ b/plugin-autoupdate-filter.php
@@ -12,7 +12,7 @@
  * Plugin URI:      https://github.com/a8cteam51/plugin-autoupdate-filter
  * Update URI:      https://github.com/a8cteam51/plugin-autoupdate-filter
  * Description:     Filters whether autoupdates are on based on day/time and other settings.
- * Version:         1.6.8
+ * Version:         1.6.9
  * Requires PHP:    7.4
  * Author:          WordPress.com Special Projects
  * Author URI:      https://wpspecialprojects.wordpress.com


### PR DESCRIPTION
## Summary

This PR brings the same centralized per-plugin autoupdate controls from Atlantis into the legacy `plugin-autoupdate-filter` plugin.

### What changed

- Added support for centralized `disabled_plugins` settings from OpsOasis.
- Updated plugin autoupdate decision logic to block plugin updates when a plugin is listed in centralized `disabled_plugins`.
- Updated plugin column UI behavior:
  - Shows: `Autoupdates have been explicitly deactivated for this plugin via global OpsOasis settings.`
  - Hides the `Disable PAF updates` action for plugins disabled globally via OpsOasis.
- Unified plugin block evaluation so legacy callback-based blocking and centralized blocking are both respected.
- Hardened `disable_all` checks to require explicit boolean `true` (strict comparison), instead of treating any set value as enabled.
- Updated docs in `README.md` to document centralized payload fields (`disable_all`, `canary_sites`, `disabled_plugins`).
- Bumped plugin version from `1.6.8` to `1.6.9`.

## Test plan

- [x] Set OpsOasis endpoint payload with `disabled_plugins` including an installed plugin (e.g. `akismet/akismet.php`).
- [x] Confirm that plugin is not auto-updated.
- [x] Confirm plugin row in `wp-admin/plugins.php` shows the OpsOasis global-disable message.
- [x] Confirm `Disable PAF updates` action is not shown for centrally disabled plugins.
- [x] Confirm plugins not listed in `disabled_plugins` still follow normal PAF schedule/delay behavior.
- [x] Set `disable_all: true` and verify all auto-updates are disabled.
- [x] Set `disable_all: false` and verify global disable does not trigger.
- [x] Run PHP syntax checks for updated files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with new centralized plugin update control settings.

* **New Features**
  * Added global disable option and per-plugin disable settings for centralized update management.
  * Enhanced admin notifications to clearly indicate what's preventing plugin updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->